### PR TITLE
fix Node.js version problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 #  && apt-get install -y python3-pip \
   && apt-get install -y git \
   && apt-get install -y zip \
+  && curl -fsSL https://deb.nodesource.com/setup_14.x | bash - \
   && apt-get install -y nodejs \
 #  && apt-get install -y unzip \
   && \


### PR DESCRIPTION
ykdl在下载斗鱼直播时会出现

> ykdl.util.jsengine.ProgramError: SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
将Node.js升级到14.x版本能解决该问题
该pr修改docker file 指定下载14.x版本的Node.js