### PR TITLE
添加对twitch的cookie支持，作用是可以不让广告嵌入到视频流中

### DIFF
--- a/biliup/plugins/huya.py
+++ b/biliup/plugins/huya.py
@@ -47,5 +47,5 @@ class Huya(DownloadBase):
             absurl = f'{huyajson["sFlvUrl"]}/{huyajson["sStreamName"]}.{huyajson["sFlvUrlSuffix"]}?' \
                      f'{huyajson["sFlvAntiCode"]}'
             self.raw_stream_url = html.unescape(absurl) + "&ratio=" + str(ratio)
-            self.room_title = json.loads(huya)['data'][0]['gameLiveInfo']['roomName']
+            self.room_title = json.loads(huya)['data'][0]['gameLiveInfo']['introduction']
             return True

--- a/biliup/plugins/twitch.py
+++ b/biliup/plugins/twitch.py
@@ -95,11 +95,15 @@ class Twitch(DownloadBase):
             self.room_title = data.get('data').get('user').get('lastBroadcast').get('title')
         if self.downloader == 'ffmpeg':
             port = random.randint(1025, 65535)
-            self.proc = subprocess.Popen([
+            stream_shell = [
                 "streamlink", "--player-external-http", "--twitch-disable-ads",
                 "--twitch-disable-hosting", "--twitch-disable-reruns",
                 "--player-external-http-port", str(port), self.url, "best"
-            ])
+            ]
+            if config.get('twitch_cookie'): 
+                twitch_cookie = "--twitch-api-header=Authorization=OAuth " + config.get('twitch_cookie')
+                stream_shell.insert(1, twitch_cookie)
+            self.proc = subprocess.Popen(stream_shell)
             self.raw_stream_url = f"http://localhost:{port}"
             i = 0
             while i < 5:

--- a/public/config.toml
+++ b/public/config.toml
@@ -20,7 +20,7 @@ filtering_threshold = 20 # 小于此大小的视频文件将会被过滤删除�
 #douyin_cookie = '__ac_nonce=123456; __ac_signature=123456;'
 # 如录制Twitch时遇见视频流中广告过多的情况，可尝试在此填入cookie，可以大幅减少视频流中的twitch广告
 # twitch_cookie获取方式：在浏览器中打开Twitch.tv，F12调出控制台，在控制台中执行：document.cookie.split("; ").find(item=>item.startsWith("auth-token="))?.split("=")[1]
-#twitch_cookie: 'asdiouo2h987r23hf2893fh923y7'
+#twitch_cookie = 'asdiouo2h987r23hf2893fh923y7'
 # Netscape 格式的 Cookies 文本路径
 #youtube_cookie = 'cookiejar.txt'
 # 检测到主播下播后延迟再次检测，单位：秒，避免特殊情况提早启动上传导致漏录

--- a/public/config.toml
+++ b/public/config.toml
@@ -18,6 +18,9 @@ filtering_threshold = 20 # 小于此大小的视频文件将会被过滤删除�
 #biliplatform = "web"
 # 如需要录制抖音请在此填入cookie需要__ac_nonce与__ac_signature的值
 #douyin_cookie = '__ac_nonce=123456; __ac_signature=123456;'
+# 如录制Twitch时遇见视频流中广告过多的情况，可尝试在此填入cookie，可以大幅减少视频流中的twitch广告
+# twitch_cookie获取方式：在浏览器中打开Twitch.tv，F12调出控制台，在控制台中执行：document.cookie.split("; ").find(item=>item.startsWith("auth-token="))?.split("=")[1]
+#twitch_cookie: 'asdiouo2h987r23hf2893fh923y7'
 # Netscape 格式的 Cookies 文本路径
 #youtube_cookie = 'cookiejar.txt'
 # 检测到主播下播后延迟再次检测，单位：秒，避免特殊情况提早启动上传导致漏录

--- a/public/config.yaml
+++ b/public/config.yaml
@@ -58,6 +58,9 @@ streamers:
 #biliplatform: web
 # 如需要录制抖音请在此填入cookie需要__ac_nonce与__ac_signature的值
 #douyin_cookie: '__ac_nonce=123456; __ac_signature=123456;'
+# 如录制Twitch时遇见视频流中广告过多的情况，可尝试在此填入cookie，可以大幅减少视频流中的twitch广告
+# twitch_cookie获取方式：在浏览器中打开Twitch.tv，F12调出控制台，在控制台中执行：document.cookie.split("; ").find(item=>item.startsWith("auth-token="))?.split("=")[1]
+#twitch_cookie: 'aisjdoiuasdoihansdoh3ooi209'
 # Netscape 格式的 Cookies 文本路径
 #youtube_cookie: 'cookiejar.txt'
 # b站提交接口，默认自动选择，可选web，client


### PR DESCRIPTION
Updata twitch.py
Updata config.yaml
Updata config.toml
streamlink原文：https://streamlink.github.io/cli/plugins/twitch.html
> In addition to that, special API request headers can be set via [--twitch-api-header](https://streamlink.github.io/cli.html#cmdoption-twitch-api-header) or special API request parameters can be set via [--twitch-access-token-param](https://streamlink.github.io/cli.html#cmdoption-twitch-access-token-param) that can prevent ads from being embedded into the stream, either [authentication data](https://streamlink.github.io/cli/plugins/twitch.html#authentication) or other data discovered by the community.