### PR TITLE
增加自定义录播文件名称的设置

### DIFF
--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -50,9 +50,17 @@ class DownloadBase:
 
     def download(self, filename):
         if self.downloader == 'stream-gears':
-            stream_gears_download(self.raw_stream_url, self.fake_headers, f'{self.fname}%Y-%m-%dT%H_%M_%S', config.get('segment_time'), config.get('file_size'))
+            if config.get('filename_prefix'):
+                filename = config.get('filename_prefix').format(self=self, nowtime=time.strftime(config.get('time_prefix')))
+            else:
+                filename = f'{self.fname}%Y-%m-%dT%H_%M_%S'
+            stream_gears_download(self.raw_stream_url, self.fake_headers, filename, config.get('segment_time'), config.get('file_size'))
         else:
-            self.ffmpeg_download(filename)
+            if config.get('filename_prefix'):
+                filename = config.get('filename_prefix').format(self=self, nowtime=time.strftime(config.get('time_prefix')))
+            else:
+                filename = filename
+        self.ffmpeg_download(filename)
 
     def ffmpeg_download(self, filename):
         default_input_args = ['-headers', ''.join('%s: %s\r\n' % x for x in self.fake_headers.items()),

--- a/public/config.toml
+++ b/public/config.toml
@@ -1,6 +1,5 @@
 # 选择全局默认上传插件，Noop为不上传，但会执行后处理,可选bili_web，biliup-rs
 #uploader = "Noop"
-
 # b站上传线路选择，默认为自动模式，目前可手动切换为bda2, kodo, ws, qn, cos, cos-internal(支持腾讯云内网免流+提速)
 lines = "AUTO"
 # 单文件并发上传数，未达到带宽上限时增大此值可提高上传速度
@@ -14,6 +13,10 @@ filtering_threshold = 20 # 小于此大小的视频文件将会被过滤删除�
 #douyucdn = "tct-h5"
 # 如遇到虎牙录制卡顿可以尝试切换线路，AL, HW, TX, WS
 #huyacdn = "AL"
+# 自定义录播文件命名规则 可使用参数 {self.fname}:你在配置里设置的直播间名 {nowtime}:创建文件的时间，可以通过time_prefix修改格式 {self.room_title} 当场直播间标题
+#filename_prefix: '[{self.fname}][{nowtime}][{self.room_title}]'
+# 自定义录播文件命名中时间的格式
+#time_prefix: '%Y-%m-%d %H_%M_%S'
 # 哔哩哔哩直播流协议.可选 stream（Flv）、hls
 #bili_protocol = "stream"
 # 哔哩哔哩直播优选CDN

--- a/public/config.yaml
+++ b/public/config.yaml
@@ -49,7 +49,11 @@ streamers:
         opt_args: # ffmpeg参数
             - '-ss' # 跳过开始的16秒
             - '00:00:16'
-
+            
+# 自定义录播文件命名规则 可使用参数 {self.fname}:你在配置里设置的直播间名 {nowtime}:创建文件的时间，可以通过time_prefix修改格式 {self.room_title} 当场直播间标题
+#filename_prefix: '[{self.fname}][{nowtime}][{self.room_title}]'
+# 自定义录播文件命名中时间的格式
+#time_prefix: '%Y-%m-%d %H_%M_%S'
 # 如遇到斗鱼录制卡顿可以尝试切换线路，tct-h5（备用线路5），ali-h5（备用线路6），akm-h5（主线路1）
 #douyucdn: tct-h5
 # 如遇到虎牙录制卡顿可以尝试切换线路，AL, HW, TX, WS


### PR DESCRIPTION
仅适用于使用stream-gear和ffmpeg下载直播的时候。转载YouTube等依旧为默认标题。