### PR TITLE
修复斗鱼直播间被关闭一直报错的问题

### DIFF
--- a/biliup/plugins/douyu.py
+++ b/biliup/plugins/douyu.py
@@ -24,6 +24,9 @@ class Douyu(DownloadBase):
                      r'room_id\s*=\s*(\d+)',
                      r'"room_id.?":(\d+)',
                      r'data-onlineid=(\d+)')
+        if not vid:
+            logger.debug("直播间" + vid + "：被关闭或不存在")
+            return False
         roominfo = requests.get(f"https://www.douyu.com/betard/{vid}").json()['room']
         videoloop = roominfo['videoLoop']
         show_status = roominfo['show_status']


### PR DESCRIPTION
比如这个直播间 `https://www.douyu.com/265769`
导致其他的斗鱼直播都不能正常录制