### PR TITLE
改进自定义API是否传Cookie的判断

### DIFF
--- a/public/config.yaml
+++ b/public/config.yaml
@@ -103,7 +103,9 @@ streamers:
 #user:
     #------哔哩哔哩------#
     ### 参照https://github.com/BililiveRecorder/BililiveRecorder/issues/263
-    # bili_cookie: ''
+    #bili_cookie: ''
+    ### 重要！！！是否将cookie传入第三方API。将Cookie传入未知的第三方API有几率泄露帐号登录信息。默认当 Cookie 存在时，仅使用官方 Api。
+    #customAPI_use_cookie : false
 
     #------抖音------#
     ### 如需要录制抖音请在此填入cookie需要__ac_nonce与__ac_signature的值

--- a/public/config.yaml
+++ b/public/config.yaml
@@ -104,8 +104,10 @@ streamers:
     #------哔哩哔哩------#
     ### 参照https://github.com/BililiveRecorder/BililiveRecorder/issues/263
     #bili_cookie: ''
-    ### 重要！！！是否将cookie传入第三方API。将Cookie传入未知的第三方API有几率泄露帐号登录信息。默认当 Cookie 存在时，仅使用官方 Api。
-    #customAPI_use_cookie : false
+    ### 重要！！！
+    ###是否将cookie传入第三方API。将Cookie传入未知的第三方API有几率泄露帐号登录信息。
+    ###默认当 Cookie 存在并且本开关关闭时，仅使用官方 Api。
+    #customAPI_use_cookie : False
 
     #------抖音------#
     ### 如需要录制抖音请在此填入cookie需要__ac_nonce与__ac_signature的值

--- a/public/config.yaml
+++ b/public/config.yaml
@@ -106,7 +106,7 @@ streamers:
     #bili_cookie: ''
     ### 重要！！！
     ###是否将cookie传入第三方API。将Cookie传入未知的第三方API有几率泄露帐号登录信息。
-    ###默认当 Cookie 存在并且本开关关闭时，仅使用官方 Api。
+    ###在开启了自定义Cookie（bili_cookie）又同时设置了第三方API（bili_liveapi）的情况下，如果打开了允许第三方API使用Cookie，那么就使用第三方API，如果没有允许（默认），那么设置的第三方API就不生效
     #customAPI_use_cookie : False
 
     #------抖音------#


### PR DESCRIPTION
这下如果有写自定义Cookie又同时设置了第三方APi的情况下。如果打开了允许第三方API使用Cookie，那么就使用第三方API，如果没有允许（默认），那么设置的第三方APi就不生效，继续使用默认的API。
