### PR TITLE
一系列更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 - 🔧已修复的问题
 - ⚠️需要手动操作的更新信息
 
+## 0.4.18
+- 更新时间：2023.04.21
+- 🔧修复录制B站直播，自动上传标题里面的title为下播前的最后一个标题的bug（正确的应该是开播之后的第一个标题）。[@haha114514](https://github.com/haha114514)
+- 🔧streamlink下载稳定与内存占用优化。[@haha114514](https://github.com/haha114514)
+- 🔧修复多余弹幕文件自动过滤失效的问题。[@haha114514](https://github.com/haha114514)
+- 🔧增加B站fmp4流的等待时间，因为有些主播开播到推流时间较慢。[@zclkkk](https://github.com/zclkkk)
+- 💡B站直播优选CDN支持同时添加多个节点。[@haha114514](https://github.com/haha114514)
+- 💡新增B站自定义fmp4流获取不到时，重新获取一遍flv直播流的API。[@haha114514](https://github.com/haha114514)
+
 ## 0.4.17
 - 更新时间：2023.03.24
 - 🔧修复不填B站自定义API就无法开始录制的问题。[@xxxxuanran](https://github.com/xxxxuanran)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - 🔧增加B站fmp4流的等待时间，因为有些主播开播到推流时间较慢。[@zclkkk](https://github.com/zclkkk)
 - 💡B站直播优选CDN支持同时添加多个节点。[@haha114514](https://github.com/haha114514)
 - 💡新增B站自定义fmp4流获取不到时，重新获取一遍flv直播流的API。[@haha114514](https://github.com/haha114514)
+- 💡新增对快手平台的支持。[@xxxxuanran](https://github.com/xxxxuanran)
 
 ## 0.4.17
 - 更新时间：2023.03.24

--- a/biliup/__init__.py
+++ b/biliup/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 
-__version__ = "0.4.17"
+__version__ = "0.4.18"
 
 LOG_CONF = {
     'version': 1,

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -96,7 +96,7 @@ class DownloadBase:
                 return live_cover_path
 
     def streamlink_download(self, filename): #streamlink+ffmpeg混合下载模式，适用于下载hls流
-        streamlink_input_args = ['--stream-segment-threads', '6', '--hls-playlist-reload-attempts', '1']
+        streamlink_input_args = ['--stream-segment-threads', '3', '--hls-playlist-reload-attempts', '1']
         streamlink_cmd = ['streamlink', *streamlink_input_args, self.raw_stream_url, 'best', '-O']
         ffmpeg_input_args = ['-reconnect_streamed', '1', '-reconnect_delay_max', '20', '-rw_timeout', '20000000']
         ffmpeg_cmd = ['ffmpeg', '-re', '-i', 'pipe:0', '-y',*ffmpeg_input_args, *self.default_output_args, *self.opt_args, '-c', 'copy', '-f', self.suffix]

--- a/biliup/engine/upload.py
+++ b/biliup/engine/upload.py
@@ -53,10 +53,10 @@ class UploadBase:
                     logger.info(f'过滤删除-{r}')
             if ext == '.xml': #过滤不存在对应视频的xml弹幕文件
                 xml_file_name = name
-                media_regex = re.compile(r'^{}({})(\.part)?$'.format(
-                    re.escape(xml_file_name), '|'.join(map(re.escape, media_extensions))
+                media_regex = re.compile(r'^{}(\.(mp4|flv|ts))?$'.format(
+                    re.escape(xml_file_name)
                 ))
-                if not any(media_regex.match(x) for x in file_list):
+                if not any(media_regex.match(f'{xml_file_name}{ext2}') for ext2 in media_extensions for x in file_list):
                     self.remove_file(r)
                     logger.info(f'无视频，已过滤删除-{r}')
         file_list = UploadBase.file_list(index)

--- a/public/config.toml
+++ b/public/config.toml
@@ -72,11 +72,16 @@ check_sourcecode = 15
 ### 由于ffmpeg只能单线程下载，并且stream-gears录制有问题，所以目前fmp4流只能使用streamlink+ffmpeg混合模式。
 #bili_protocol = "stream"
 ### 哔哩哔哩直播优选CDN，默认无
-#bili_perfCDN = "cn-gotcha01"
+#bili_perfCDN = "cn-gotcha208,ov-gotcha05"
 ### 哔哩哔哩直播强制原画（仅限HLS流的 cn-gotcha01 CDN），默认为关闭
 #bili_force_source = false
-### 自定义哔哩哔哩直播api，默认无
+### 自定义哔哩哔哩直播API，用于获取指定区域（大陆或者海外）的直播流链接，默认使用官方API。
 #bili_liveapi = "https://api.live.bilibili.com"
+### 自定义fmp4流获取不到时，重新获取一遍flv直播流的api，默认不重新使用其他api重新获取一遍。
+### 海外机器玩法：bili_liveapi设置为能获取大陆直播流的API，并将bili_fallback_api设置为官方API，然后优选fmp4流并使用streamlink下载器，最后设置优选cn-gotcha208,ov-gotcha05两个节点。
+### 大陆机器玩法：bili_liveapi取消注释保持默认使用官方API，并将bili_fallback_api设置为能获取到海外节点API，然后优选fmp4流并使用streamlink下载器，最后设置优选cn-gotcha208,ov-gotcha05两个节点。
+### 这样大主播可以使用cn208的fmp4流稳定录制（海外机如需可以通过自建dns优选指定线路的cn208节点），没有fmp4流的小主播也可以会退到ov05录制flv流。
+#bili_fallback_api = 'https://api.live.bilibili.com'
 ### CDN自动Fallback开关，默认为开启
 #bili_cdn_fallback = true
 ### 强制替换ov-gotcha05的下载地址为指定的自选IP
@@ -143,7 +148,7 @@ uploader = "biliup-rs"  # 覆盖全局默认上传插件，Noop为不上传，�
 user_cookie = "cookies.json" # 使用指定的账号上传
 #use_live_cover = true # 获取BILIBILI直播间封面并作为投稿封面。此封面优先级低于单个主播指定的自定义封面。
 tags = [ "biliup", "视频标签" ]
-format = "mp4" # 视频保存格式。如需使用mp4格式，必须切换downloader为ffmpeg。
+format = "mp4" # 视频保存格式。如需使用mp4格式，必须切换downloader为ffmpeg或者streamlink。
 # 上传完成后，将按自定义顺序执行自定义操作
 #postprocessor = [
 #    {run = "echo hello!"}, # 执行任意命令，等同于在shell中运行,视频文件路径作为标准输入传入

--- a/public/config.toml
+++ b/public/config.toml
@@ -23,7 +23,7 @@ filtering_threshold = 20
 #submit_api = "client"
 # 选择全局默认上传插件，Noop为不上传，但会执行后处理,可选bili_web，biliup-rs
 #uploader = "Noop"
-# b站上传线路选择，默认为自动模式，目前可手动切换为bda2, kodo, ws, qn, cos, cos-internal(支持腾讯云内网免流+提速)
+# b站上传线路选择，默认为自动模式，目前可手动切换为bda2, kodo, ws, qn, cos, cos-internal(支持腾讯云内网免流+提速，目前已失效)
 lines = "AUTO"
 # 单文件并发上传数，未达到带宽上限时增大此值可提高上传速度
 threads = 3
@@ -80,7 +80,7 @@ check_sourcecode = 15
 ### 自定义fmp4流获取不到时，重新获取一遍flv直播流的api，默认不重新使用其他api重新获取一遍。
 ### 海外机器玩法：bili_liveapi设置为能获取大陆直播流的API，并将bili_fallback_api设置为官方API，然后优选fmp4流并使用streamlink下载器，最后设置优选cn-gotcha208,ov-gotcha05两个节点。
 ### 大陆机器玩法：bili_liveapi取消注释保持默认使用官方API，并将bili_fallback_api设置为能获取到海外节点API，然后优选fmp4流并使用streamlink下载器，最后设置优选cn-gotcha208,ov-gotcha05两个节点。
-### 这样大主播可以使用cn208的fmp4流稳定录制（海外机如需可以通过自建dns优选指定线路的cn208节点），没有fmp4流的小主播也可以会退到ov05录制flv流。
+### 这样大主播可以使用cn208的fmp4流稳定录制（海外机如需可以通过自建dns优选指定线路的cn208节点），没有fmp4流的小主播也可以回退到ov05（网宿线路，包括大陆与海外节点）录制flv流。
 #bili_fallback_api = 'https://api.live.bilibili.com'
 ### CDN自动Fallback开关，默认为开启
 #bili_cdn_fallback = true

--- a/public/config.yaml
+++ b/public/config.yaml
@@ -36,9 +36,9 @@ event_loop_interval: 40
 ### 相同平台检测间隔，单位：秒。不同平台的链接是并发的，不受此参数影响
 checker_sleep: 15
 ### 线程池1大小，负责download事件
-pool1_size: 3
+pool1_size: 5
 ### 线程池2大小，处理除download事件外所有其他事件
-pool2_size: 3
+pool2_size: 5
 ### 检测源码文件变化间隔，单位：秒，检测源码到变化后，程序会在空闲时自动重启
 check_sourcecode: 15
 
@@ -69,17 +69,22 @@ check_sourcecode: 15
 ### 目前的策略是，如果开播时间小于60s，将会反复尝试获取fmp4流，如果没获取到就回退到flv流。
 ### 由于ffmpeg只能单线程下载，并且stream-gears录制有问题，所以目前fmp4流只能使用streamlink+ffmpeg混合模式。
 #bili_protocol: stream
-### 哔哩哔哩直播优选CDN，默认无
-#bili_perfCDN: cn-gotcha01
+### 哔哩哔哩直播优选CDN，默认无，支持同时填入多个CDN节点。
+#bili_perfCDN: 'cn-gotcha208,ov-gotcha05'
 ### 哔哩哔哩直播强制原画（仅限HLS流的 cn-gotcha01 CDN），默认为关闭
 #bili_force_source: false
-### 自定义哔哩哔哩直播api，默认无
+### 自定义哔哩哔哩直播API，用于获取指定区域（大陆或者海外）的直播流链接，默认使用官方API。
 #bili_liveapi: 'https://api.live.bilibili.com'
+### 自定义fmp4流获取不到时，重新获取一遍flv直播流的api，默认不重新使用其他api重新获取一遍。
+### 海外机器玩法：bili_liveapi设置为能获取大陆直播流的API，并将bili_fallback_api设置为官方API，然后优选fmp4流并使用streamlink下载器，最后设置优选cn-gotcha208,ov-gotcha05两个节点。
+### 大陆机器玩法：bili_liveapi取消注释保持默认使用官方API，并将bili_fallback_api设置为能获取到海外节点API，然后优选fmp4流并使用streamlink下载器，最后设置优选cn-gotcha208,ov-gotcha05两个节点。
+### 这样大主播可以使用cn208的fmp4流稳定录制（海外机如需可以通过自建dns优选指定线路的cn208节点），没有fmp4流的小主播也可以会退到ov05录制flv流。
+#bili_fallback_api: 'https://api.live.bilibili.com'
 ### CDN自动Fallback开关，默认为开启
 #bili_cdn_fallback: true
 ### 强制替换ov-gotcha05的下载地址为指定的自选IP
 #bili_force_ov05_ip: '163.171.197.234'
-### 强制替换cn-gotcha01（叔叔自建，理论上最稳定）为指定的自选域名组（可多个域名，请用逗号分隔）
+### 强制替换cn-gotcha01（叔叔自建）为指定的自选域名组（可多个域名，请用逗号分隔）
 ### 完整CDN列表请参考 https://rec.danmuji.org/dev/bilibili-cdn/ 中"B站视频云"的部分
 ### 此功能目前会和stream-gears冲突导致很多分段，请考虑使用ffmpeg录制
 ### 如果海外机器需要使用此功能，需要在bili_liveapi中指定国内的反代API来获取cn-gotcha01的节点信息。
@@ -149,7 +154,7 @@ streamers:
         tags:
             - biliup
             - 视频标签
-        format: mp4 ### 视频保存格式。如需使用mp4格式，必须切换downloader为ffmpeg。
+        format: mp4 ### 视频保存格式。如需使用mp4格式，必须切换downloader为ffmpeg或者streamlink。
         opt_args: ### ffmpeg参数
             - '-ss' # 跳过开始的16秒
             - '00:00:16'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "aiohttp[speedups]",
     "Requests >= 2.20.0",
     "PyYAML >= 4.2b1",
-    "streamlink >= 5.3.0",
+    "streamlink >= 5.4.0",
     "ykdl >= 1.8.0",
     "rsa >= 4.6",
     'importlib-resources; python_version<"3.9"',


### PR DESCRIPTION
- 更新时间：2023.04.21
- 🔧修复录制B站直播，自动上传标题里面的title为下播前的最后一个标题的bug（正确的应该是开播之后的第一个标题）。[@haha114514](https://github.com/haha114514)
- 🔧streamlink下载稳定与内存占用优化。[@haha114514](https://github.com/haha114514)
- 🔧修复多余弹幕文件自动过滤失效的问题。[@haha114514](https://github.com/haha114514)
- 🔧增加B站fmp4流的等待时间，因为有些主播开播到推流时间较慢。[@zclkkk](https://github.com/zclkkk)
- 💡B站直播优选CDN支持同时添加多个节点。[@haha114514](https://github.com/haha114514)
- 💡新增B站自定义fmp4流获取不到时，重新获取一遍flv直播流的API。[@haha114514](https://github.com/haha114514)
- - 💡新增对快手平台的支持。[@xxxxuanran](https://github.com/xxxxuanran)
