### PR TITLE
Update bili_webup.py

### DIFF
--- a/biliup/plugins/bili_webup.py
+++ b/biliup/plugins/bili_webup.py
@@ -83,7 +83,7 @@ class BiliBili:
             self.appsec = 'c75875c596a69eb55bd119e74b07cfe3'
         self.__session = requests.Session()
         self.video = video
-        self.__session.mount('https://', HTTPAdapter(max_retries=Retry(total=5, method_whitelist=False)))
+        self.__session.mount('https://', HTTPAdapter(max_retries=Retry(total=5)))
         self.__session.headers.update({
             "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/63.0.3239.108",
             "Referer": "https://www.bilibili.com/", 'Connection': 'keep-alive'


### PR DESCRIPTION
urllib3 2.x版本中去掉了method_whitelist, 通过--http启动时会报错
已在旧版1.26.15测试过, 删除后没问题