### PR TITLE
Some improvements

### DIFF
--- a/biliup/plugins/bilibili.py
+++ b/biliup/plugins/bilibili.py
@@ -136,7 +136,7 @@ class Bilibili(DownloadBase):
                         if s.get(self.raw_stream_url, stream=True).status_code == 200:
                             break
             except Exception:
-                logger.error('')
+                pass
         return True
 
     async def danmaku_download_start(self, filename):

--- a/biliup/plugins/douyu.py
+++ b/biliup/plugins/douyu.py
@@ -1,5 +1,3 @@
-from collections import namedtuple
-
 import requests
 from ykdl.util.match import match1
 
@@ -17,9 +15,8 @@ class Douyu(DownloadBase):
         self.douyu_danmaku = config.get('douyu_danmaku', False)
 
     def check_stream(self):
-        from ykdl.extractors.douyu.util import ub98484234
         if len(self.url.split("douyu.com/")) < 2:
-            logger.error("直播间地址:" + self.url + " 错误")
+            logger.debug("直播间地址:" + self.url + " 错误")
             return False
         html = requests.get(self.url).text
         vid = match1(html, r'\$ROOM\.room_id\s*=\s*(\d+)',
@@ -27,23 +24,26 @@ class Douyu(DownloadBase):
                      r'"room_id.?":(\d+)',
                      r'data-onlineid=(\d+)')
         if not vid:
-            logger.error("直播间" + vid + "：被关闭或不存在")
+            logger.debug("直播间" + vid + "：被关闭或不存在")
             return False
         roominfo = requests.get(f"https://www.douyu.com/betard/{vid}").json()['room']
         if roominfo['show_status'] != 1 or roominfo['videoLoop'] != 0:
-            logger.error("直播间" + vid + "：未开播或正在放录播")
+            logger.debug("直播间" + vid + "：未开播或正在放录播")
             return False
         self.room_title = roominfo['room_name']
         html_h5enc = requests.get(f'https://www.douyu.com/swf_api/homeH5Enc?rids={vid}').json()
         js_enc = html_h5enc['data']['room' + vid]
         params = {
-            'cdn': config.get('douyucdn', ''),
+            'cdn': config.get('douyucdn', 'tct-h5'),
             'iar': 0,
             'ive': 0,
             'rate': 0,
         }
-        Extractor = namedtuple('Extractor', ['vid', 'logger'])
-        ub98484234(js_enc, Extractor(vid, logger), params)
+        try:
+            ub98484234(js_enc, vid, params)
+        except:
+            logger.error('请至少安装一个 Javascript 解释器')
+            return False
         live_data = get_play_info(vid, self.fake_headers, params)
         if type(live_data) is not dict:
             return False
@@ -61,18 +61,23 @@ class Douyu(DownloadBase):
             self.danmaku.stop()
             logger.info("结束弹幕录制")
 
-def get_play_info(vid, fake_headers, params):
-    import random
-    try:
-        html_content = requests.post(f'https://www.douyu.com/lapi/live/getH5Play/{vid}', headers=fake_headers,
-                                params=params).json()
-        live_data = html_content["data"]
-        # 尝试规避斗鱼自建scdn
-        # scdn 仅在该省市的ISP首次访问上方API后才会新增，且在新增后两分钟内无流可用（404）
-        if not live_data['rtmp_cdn'].endswith('h5'):
-            while not params['cdn'].endswith('h5'):
-                params['cdn'] = random.choice(live_data['cdnsWithName']).get('cdn')
-            return get_play_info(vid, fake_headers, params)
-    except Exception:
-        return None
+def get_play_info(vid, headers, params):
+    html_content = requests.post(f'https://www.douyu.com/lapi/live/getH5Play/{vid}', headers=headers, params=params).json()
+    live_data = html_content["data"]
+    # 禁用斗鱼主线路
+    if not live_data['rtmp_cdn'].endswith('h5') or 'akm' in live_data['rtmp_cdn']:
+        params['cdn'] = 'tct-h5'
+        return get_play_info(vid, headers, params)
     return live_data
+
+def ub98484234(js_enc, vid, params):
+    import jsengine
+    import uuid
+    import time
+    from urllib.parse import parse_qs
+    did = uuid.uuid4().hex
+    tt = str(int(time.time()))
+    crypto_js = requests.get('https://cdn.staticfile.org/crypto-js/4.1.1/crypto-js.min.js').text
+    js = jsengine.JSEngine(js_enc + crypto_js)
+    query = js.call('ub98484234', vid, did, tt)
+    params.update({k: v[0] for k, v in parse_qs(query).items()})

--- a/biliup/plugins/huya.py
+++ b/biliup/plugins/huya.py
@@ -31,7 +31,7 @@ class Huya(DownloadBase):
             else:
                 huya = None
         if huya:
-            huyacdn = config.get('huyacdn') if config.get('huyacdn') else 'AL'
+            huyacdn = config.get('huyacdn', 'AL')
             huyajson1 = json.loads(huya)['data'][0]['gameStreamInfoList']
             huyajson2 = json.loads(huya)['vMultiStreamInfo']
             ratio = huyajson2[0]['iBitRate']

--- a/biliup/plugins/kuaishou.py
+++ b/biliup/plugins/kuaishou.py
@@ -1,31 +1,113 @@
 import json
 import requests
 
+from biliup.config import config
 from ..engine.decorators import Plugin
-from ..plugins import logger
+from ..plugins import match1, logger
 from ..engine.download import DownloadBase
 
-@Plugin.download(regexp=r'(?:https?://)?(?:(?:live|www)\.)?kuaishou\.com')
+@Plugin.download(regexp=r'(?:https?://)?(?:(?:live|www|v)\.)?(kuaishou)\.com')
+@Plugin.download(regexp=r'(?:https?://)?(?:(?:(?:livev)\.(?:m))\.)?chenzhongtech\.com')
 class Kuaishou(DownloadBase):
     def __init__(self, fname, url, suffix='flv'):
         super().__init__(fname, url, suffix)
 
     def check_stream(self):
+
+        '''
+        Api
+        '''
+        # split_args = ["/profile/", "/fw/live/"]
+        # for split_key in split_args:
+        #     if split_key in self.url:
+        #         self.url = f"https://live.kuaishou.com/u/{self.url.split(split_key)[1]}"
+        # from urllib.parse import urlparse
+        # r = requests.get(self.url, headers=self.fake_headers)
+        # parsed_url = urlparse(r.url)
+        # kwaiId = parsed_url.path.split('/')[-1]
+        # kwai_data = requests.get(f'https://live.kuaishou.com/live_api/profile/public?principalId={kwaiId}',
+        #              headers=self.fake_headers).json()
+        # live_data = kwai_data['data']['live']
+        # # 被风控时会返回未开播
+        # if not live_data['living']:
+        #     logger.debug(kwaiId + '未开播')
+        #     return False
+        # self.room_title = live_data['caption']
+        # self.raw_stream_url = live_data['playUrls'][0]['adaptationSet']['representation'][-1]['url']
+
+
+        '''
+        Phone_WEB
+        '''
+        # 可以输入 快手号(kwaiId), 用户唯一辨识ID(userEid), v.kuaishou.com 短链
+        # livev.m.chenzhongtech.com 移动端链接也需要刷新验证参数
+        split_args = ["/profile/", "/fw/live/"]
+        for split_key in split_args:
+            if split_key in self.url:
+                self.url = f"https://live.kuaishou.com/u/{self.url.split(split_key)[1]}"
+        headers = self.fake_headers.copy()
+        headers['User-Agent'] = 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1'
         with requests.Session() as s:
-            if "/profile/" in self.url:
-                self.url = f"https://live.kuaishou.com/u/{self.url.split('/profile/')[1]}"
-            res = s.get(self.url, timeout=5, headers=self.fake_headers)
-        initial_state = res.text.split('window.__INITIAL_STATE__=')[1].split(';(')[0]
-        liveroom = json.loads(initial_state)['liveroom']
-        if liveroom['errorType']['type'] != 1:
-            logger.error("直播间不存在或链接错误")
+            s.headers.update(headers)
+            r = s.get(self.url)
+            from urllib.parse import urlparse, parse_qs
+            parsed_url = urlparse(r.url)
+            query_params = parse_qs(parsed_url.query)
+            eid = parsed_url.path.split('/')[-1]
+            kpn = query_params.get('kpn')[0]
+            s.headers.update({
+                'Origin': 'https://livev.m.chenzhongtech.com',
+                'Referer': r.url,
+                'Content-Type': 'application/json',
+            })
+            data = {
+                'source': 6,
+                'eid': eid,
+                'shareMethod': 'card',
+                'clientType': 'WEB_OUTSIDE_SHARE_H5'
+            }
+            # 我不好说，但距离上面获取移动端页面的请求必须间隔 1s 以上
+            import time
+            time.sleep(3)
+            live_data = s.post(f"https://livev.m.chenzhongtech.com/rest/k/live/byUser?kpn={kpn}",
+                                json=data).json()
+        if not live_data['result'] == 1 :
+            logger.error(live_data['error_msg'])
             return False
-        liveStream = liveroom['liveStream']
-        if not liveroom['isLiving'] or liveStream['type'] not in 'live':
-            logger.error("直播间未开播或播放的不是直播")
+        liveStream = live_data['liveStream']
+        # liveStream['type'] != 2 or liveStream['streamType'] != 1 可能是视频轮播，未发现相关主播
+        if not liveStream['living']:
+            logger.debug(liveStream['user']['user_name'] + "未开播")
             return False
-        self.raw_stream_url = liveStream['playUrls'][0]['adaptationSet']['representation'][-1]['url']
         self.room_title = liveStream['caption']
+        playUrls = liveStream['playUrls']
+        # if 'hls' in config.get('kuaishou_protocol'):
+        #     self.raw_stream_url = liveStream['hlsPlayUrl']
+        #     return True
+        self.raw_stream_url = playUrls[0]['url']
+        # for playUrl in playUrls:
+        #     if playUrl['cdn'] in config.get('kuaishou_cdn'):
+        #         self.raw_stream_url = playUrl['url']
+
+
+        '''
+        PC_WEB
+        '''
+        # with requests.Session() as s:
+        #     if "/profile/" in self.url:
+        #         self.url = f"https://live.kuaishou.com/u/{self.url.split('/profile/')[1]}"
+        #     res = s.get(self.url, timeout=5, headers=self.fake_headers)
+        # initial_state = res.text.split('window.__INITIAL_STATE__=')[1].split(';(')[0]
+        # liveroom = json.loads(initial_state)['liveroom']
+        # if liveroom['errorType']['type'] != 1:
+        #     logger.debug(liveroom['errorType']['title'])
+        #     return False
+        # liveStream = liveroom['liveStream']
+        # if not liveroom['isLiving'] or liveStream['type'] not in 'live':
+        #     logger.debug("直播间未开播或播放的不是直播")
+        #     return False
+        # self.raw_stream_url = liveStream['playUrls'][0]['adaptationSet']['representation'][-1]['url']
+        # self.room_title = liveStream['caption']
         # author = liveroom['author']
         # if self.use_live_cover is True:
         #     try:

--- a/biliup/plugins/missevan.py
+++ b/biliup/plugins/missevan.py
@@ -31,7 +31,7 @@ class Missevan(DownloadBase):
                 end = user_page.text.find('"', start)
                 rid = user_page.text[start:end]
             else:
-                logger.error(user_page.status_code)
+                logger.debug(user_page.status_code)
         if self.url.split("live"):
             rid = match1(self.url, r'/(\d+)')
 
@@ -39,13 +39,13 @@ class Missevan(DownloadBase):
 
         # 无直播间的情况
         if room_info['code'] != 0:
-            logger.error(room_info['info'])
+            logger.debug(room_info['info'])
             return False
 
         # 开播状态
         if room_info['info']['room']['status']['open'] == 0:
             creator_username = room_info['info']['room']['creator_username']
-            logger.error(f"猫耳FM：主播{creator_username}未开播")
+            logger.debug(f"主播{creator_username}未开播")
             return False
 
         self.room_title = room_info['info']['room']['name']


### PR DESCRIPTION
1. #421 改正日志等级
2. #437 尝试修复斗鱼，同时禁用主线路
 > 斗鱼海外的主线路 `akm-h5` 会使用 `hls` 分片，同时卡顿丢帧严重，疑似回源问题（2023.05.18 测试时，日本 IP 已不再返回 主线路）
国内的主线路为斗鱼自建 `scdn`，类似于 `p2p`，有卡顿现象
综上，推荐使用其他 `cdn` 获得正常录制体验
3. #427 修正日志提示，尝试规避风控