### PR TITLE
修复获取直播流失败后需要等delay触发

### DIFF
--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -177,12 +177,14 @@ class DownloadBase:
             finally:
                 self.close()
             if ret is False:
-                if config.get('delay'):
-                    time.sleep(config.get('delay'))
-                    logger.info(f"delay: {config.get('delay')}")
-                    if self.check_stream():
-                        time.sleep(5)
-                        continue
+                logger.error(f"获取直播流失败，等待5秒尝试重新获取")
+                time.sleep(5)
+                if self.check_stream():
+                    continue
+                else:
+                    if config.get('delay'):
+                        time.sleep(config.get('delay'))
+                        logger.info(f"delay: {config.get('delay')}")
                 break
             elif ret == 1 or self.downloader == 'stream-gears':
                 time.sleep(45)

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -180,6 +180,7 @@ class DownloadBase:
                 if i < 4:
                     logger.info(f"获取直播流失败{i}，等待5秒尝试重新获取")
                     time.sleep(5)
+                    i += 1
                     continue
                 else:
                     if config.get('delay'):

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -177,14 +177,17 @@ class DownloadBase:
             finally:
                 self.close()
             if ret is False:
-                logger.error(f"获取直播流失败，等待5秒尝试重新获取")
-                time.sleep(5)
-                if self.check_stream():
+                if i < 4:
+                    logger.error(f"获取直播流失败{i}，等待10秒尝试重新获取")
+                    time.sleep(10)
                     continue
                 else:
                     if config.get('delay'):
                         time.sleep(config.get('delay'))
                         logger.info(f"delay: {config.get('delay')}")
+                        if self.check_stream():
+                            time.sleep(5)
+                            continue
                 break
             elif ret == 1 or self.downloader == 'stream-gears':
                 time.sleep(45)

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -178,8 +178,8 @@ class DownloadBase:
                 self.close()
             if ret is False:
                 if i < 4:
-                    logger.error(f"获取直播流失败{i}，等待10秒尝试重新获取")
-                    time.sleep(10)
+                    logger.info(f"获取直播流失败{i}，等待5秒尝试重新获取")
+                    time.sleep(5)
                     continue
                 else:
                     if config.get('delay'):

--- a/biliup/plugins/huya.py
+++ b/biliup/plugins/huya.py
@@ -19,8 +19,11 @@ class Huya(DownloadBase):
 
     def check_stream(self):
         logger.debug(self.fname)
-        res = requests.get(self.url, timeout=5, headers=self.fake_headers)
-        res.close()
+        try:
+            res = requests.get(self.url, timeout=5, headers=self.fake_headers)
+            res.close()
+        except:
+            return False
         huya = None
         if match1(res.text, '"stream": "([a-zA-Z0-9+=/]+)"'):
             huya = base64.b64decode(match1(res.text, '"stream": "([a-zA-Z0-9+=/]+)"')).decode()

--- a/biliup/plugins/huya.py
+++ b/biliup/plugins/huya.py
@@ -19,11 +19,8 @@ class Huya(DownloadBase):
 
     def check_stream(self):
         logger.debug(self.fname)
-        try:
-            res = requests.get(self.url, timeout=5, headers=self.fake_headers)
-            res.close()
-        except:
-            return False
+        res = requests.get(self.url, timeout=5, headers=self.fake_headers)
+        res.close()
         huya = None
         if match1(res.text, '"stream": "([a-zA-Z0-9+=/]+)"'):
             huya = base64.b64decode(match1(res.text, '"stream": "([a-zA-Z0-9+=/]+)"')).decode()


### PR DESCRIPTION
问题来源 在录制抖音的时候偶尔会获取直播流失败
![image](https://github.com/biliup/biliup/assets/24969684/78a87419-da10-467e-a9c6-77b1d267f7d9)

测试中! 待验证是否成功