### PR TITLE
bili_web上传插件新增简介@功能

### DIFF
--- a/biliup/plugins/bili_webup.py
+++ b/biliup/plugins/bili_webup.py
@@ -66,9 +66,6 @@ class BiliWeb(UploadBase):
                     "biz_id": "",
                     "type": 1
                 }]
-                video_part['title'] = video_part['title'][:80]
-                video.append(video_part)  # 添加已经上传的视频
-            video.title = self.data["format_title"][:80]  # 稿件标题限制80字
             video.desc = self.desc
             video.copyright = self.copyright
             if self.copyright == 2:

--- a/biliup/plugins/bili_webup.py
+++ b/biliup/plugins/bili_webup.py
@@ -42,6 +42,7 @@ class BiliWeb(UploadBase):
         self.tags = tags
         self.cover_path = cover_path
         self.desc = description
+        self.credits = credits
         self.dynamic = dynamic
         self.copyright = copyright
         self.dtime = dtime

--- a/biliup/plugins/biliuprs.py
+++ b/biliup/plugins/biliuprs.py
@@ -28,6 +28,7 @@ class BiliWeb(UploadBase):
         else:
             self.cover_path = None
         self.desc = description
+        self.credits = credits
         self.dynamic = dynamic
         self.copyright = copyright
         self.dtime = dtime


### PR DESCRIPTION
使用`@credit`占位,credits数组按顺序插入简介中,配置示例:
description = """
【{streamer}】{title}
@credit直播时间:%Y-%m-%d %H:%M:%S
@credit直播间地址：{url}
"""
#占位符数量不能少于credits中的的用户数
credits = [
    {username="张三",uid=1234},
    {username="李四",uid=1421421}
]