### PR TITLE
fix credits in config.yaml

### DIFF
--- a/public/config.yaml
+++ b/public/config.yaml
@@ -172,9 +172,9 @@ streamers:
          ---
          Powered By biliup - Github: https://github.com/ForgQi/biliup
         ### 如需在简介中@别人 请使用以下模版
-        #credits:
+        # credits:
         #    - username: 需要@的用户名
-        #    - uid: 需要@的uid
+        #      uid: 需要@的uid
         #description: |-
         # 视频简介: {title} %Y-%m-%d %H:%M:%S
         # {streamer}主播直播间地址：{url}


### PR DESCRIPTION
使用config.yaml中举例的credits配置会导致错误: KeyError: 'uid'
参考toml中正确的配置修改了config.yaml中credits的使用注释