### PR TITLE
强制选择UpOS模式下的线路

### DIFF
--- a/biliup/plugins/bili_webup.py
+++ b/biliup/plugins/bili_webup.py
@@ -386,10 +386,12 @@ class BiliBili:
                 'name': f.name,
                 'size': total_size,
             }
-            ret = self.__session.get(
+            resp = self.__session.get(
                 f"https://member.bilibili.com/preupload?{self._auto_os['query']}", params=query,
                 timeout=5)
-            return asyncio.run(upload(f, total_size, ret.json(), tasks=tasks))
+            ret = resp.json()
+            logger.debug(ret)
+            return asyncio.run(upload(f, total_size, ret, tasks=tasks))
 
     async def cos(self, file, total_size, ret, chunk_size=10485760, tasks=3, internal=False):
         filename = file.name

--- a/biliup/plugins/bili_webup.py
+++ b/biliup/plugins/bili_webup.py
@@ -398,18 +398,18 @@ class BiliBili:
                 timeout=5)
             ret = resp.json()
             logger.debug(f"preupload: {ret}")
-            if self._auto_os['os'] == 'upos' and preferred_upos_cdn:
+            if preferred_upos_cdn:
                 original_endpoint: str = ret['endpoint']
                 if re.match(r'//upos-(sz|cs)-upcdn(bda2|ws|qn)\.bilivideo\.com', original_endpoint):
                     if re.match(r'bda2|qn|ws', preferred_upos_cdn):
-                        logger.debug(f"Preferred UPOS CDN: {preferred_upos_cdn}")
+                        logger.debug(f"Preferred UpOS CDN: {preferred_upos_cdn}")
                         new_endpoint = re.sub(r'upcdn(bda2|qn|ws)', f'upcdn{preferred_upos_cdn}', original_endpoint)
                         logger.debug(f"{original_endpoint} => {new_endpoint}")
                         ret['endpoint'] = new_endpoint
                     else:
                         logger.error(f"Unrecognized preferred_upos_cdn: {preferred_upos_cdn}")
                 else:
-                    logger.warning(f"Assigned UPOS endpoint {original_endpoint} was never seen before, something else might have changed, so will not modify it")
+                    logger.warning(f"Assigned UpOS endpoint {original_endpoint} was never seen before, something else might have changed, so will not modify it")
             return asyncio.run(upload(f, total_size, ret, tasks=tasks))
 
     async def cos(self, file, total_size, ret, chunk_size=10485760, tasks=3, internal=False):

--- a/biliup/plugins/bili_webup.py
+++ b/biliup/plugins/bili_webup.py
@@ -536,7 +536,7 @@ class BiliBili:
             "X-Upos-Auth": auth
         }
         # 向上传地址申请上传，得到上传id等信息
-        upload_id = self.__session.post(f'{url}?uploads&output=json', timeout=5,
+        upload_id = self.__session.post(f'{url}?uploads&output=json', timeout=15,
                                         headers=headers).json()["upload_id"]
         # 开始上传
         parts = []  # 分块信息
@@ -564,8 +564,8 @@ class BiliBili:
             'output': 'json',
             'profile': 'ugcupos/bup'
         }
-        ii = 0
-        while ii <= 3:
+        attempt = 0
+        while attempt <= 5:  # 一旦放弃就会丢失前面所有的进度，多试几次吧
             try:
                 r = self.__session.post(url, params=p, json={"parts": parts}, headers=headers, timeout=15).json()
                 if r.get('OK') == 1:
@@ -573,8 +573,8 @@ class BiliBili:
                     return {"title": splitext(filename)[0], "filename": splitext(basename(upos_uri))[0], "desc": ""}
                 raise IOError(r)
             except IOError:
-                ii += 1
-                logger.info(f"请求合并分片时出现问题，尝试重连，次数：" + str(ii))
+                attempt += 1
+                logger.info(f"请求合并分片时出现问题，尝试重连，次数：" + str(attempt))
                 time.sleep(15)
 
     @staticmethod

--- a/biliup/plugins/bili_webup.py
+++ b/biliup/plugins/bili_webup.py
@@ -574,7 +574,7 @@ class BiliBili:
                 raise IOError(r)
             except IOError:
                 ii += 1
-                logger.info("上传出现问题，尝试重连，次数：" + str(ii))
+                logger.info(f"请求合并分片时出现问题，尝试重连，次数：" + str(ii))
                 time.sleep(15)
 
     @staticmethod

--- a/biliup/plugins/bili_webup.py
+++ b/biliup/plugins/bili_webup.py
@@ -328,7 +328,7 @@ class BiliBili:
         auto_os['cost'] = min_cost
         return auto_os
 
-    def upload_file(self, filepath: str, lines='AUTO', tasks=3, preferred_upos_cdn: str = None):
+    def upload_file(self, filepath: str, lines='AUTO', tasks=3):
         """上传本地视频文件,返回视频信息dict
         b站目前支持4种上传线路upos, kodo, gcs, bos
         gcs: {"os":"gcs","query":"bucket=bvcupcdngcsus&probe_version=20221109",
@@ -336,6 +336,7 @@ class BiliBili:
         bos: {"os":"bos","query":"bucket=bvcupcdnboshb&probe_version=20221109",
         "probe_url":"??"}
         """
+        preferred_upos_cdn = None
         if not self._auto_os:
             if lines == 'kodo':
                 self._auto_os = {"os": "kodo", "query": "bucket=bvcupcdnkodobm&probe_version=20221109",
@@ -343,18 +344,23 @@ class BiliBili:
             elif lines == 'bda2':
                 self._auto_os = {"os": "upos", "query": "upcdn=bda2&probe_version=20221109",
                                  "probe_url": "//upos-sz-upcdnbda2.bilivideo.com/OK"}
+                preferred_upos_cdn = 'bda2'
             elif lines == 'cs-bda2':
                 self._auto_os = {"os": "upos", "query": "upcdn=bda2&probe_version=20221109",
                                  "probe_url": "//upos-cs-upcdnbda2.bilivideo.com/OK"}
+                preferred_upos_cdn = 'bda2'
             elif lines == 'ws':
                 self._auto_os = {"os": "upos", "query": "upcdn=ws&probe_version=20221109",
                                  "probe_url": "//upos-sz-upcdnws.bilivideo.com/OK"}
+                preferred_upos_cdn = 'ws'
             elif lines == 'qn':
                 self._auto_os = {"os": "upos", "query": "upcdn=qn&probe_version=20221109",
                                  "probe_url": "//upos-sz-upcdnqn.bilivideo.com/OK"}
+                preferred_upos_cdn = 'qn'
             elif lines == 'cs-qn':
                 self._auto_os = {"os": "upos", "query": "upcdn=qn&probe_version=20221109",
                                  "probe_url": "//upos-cs-upcdnqn.bilivideo.com/OK"}
+                preferred_upos_cdn = 'qn'
             elif lines == 'cos':
                 self._auto_os = {"os": "cos", "query": "",
                                  "probe_url": ""}

--- a/biliup/plugins/bili_webup.py
+++ b/biliup/plugins/bili_webup.py
@@ -390,7 +390,7 @@ class BiliBili:
                 f"https://member.bilibili.com/preupload?{self._auto_os['query']}", params=query,
                 timeout=5)
             ret = resp.json()
-            logger.debug(ret)
+            logger.debug(f"preupload: {ret}")
             return asyncio.run(upload(f, total_size, ret, tasks=tasks))
 
     async def cos(self, file, total_size, ret, chunk_size=10485760, tasks=3, internal=False):

--- a/biliup/plugins/bili_webup.py
+++ b/biliup/plugins/bili_webup.py
@@ -400,15 +400,16 @@ class BiliBili:
             logger.debug(f"preupload: {ret}")
             if self._auto_os['os'] == 'upos' and preferred_upos_cdn:
                 original_endpoint: str = ret['endpoint']
-                if re.match(r'upos-(sz|cs)-upcdn(bda2|ws|qn)\.bilivideo\.com', original_endpoint):
+                if re.match(r'//upos-(sz|cs)-upcdn(bda2|ws|qn)\.bilivideo\.com', original_endpoint):
                     if re.match(r'bda2|qn|ws', preferred_upos_cdn):
-                        new_endpoint = re.sub(r'uncdn(bda2|qn|ws)', preferred_upos_cdn, original_endpoint)
+                        logger.debug(f"Preferred UPOS CDN: {preferred_upos_cdn}")
+                        new_endpoint = re.sub(r'upcdn(bda2|qn|ws)', f'upcdn{preferred_upos_cdn}', original_endpoint)
                         logger.debug(f"{original_endpoint} => {new_endpoint}")
                         ret['endpoint'] = new_endpoint
                     else:
                         logger.error(f"Unrecognized preferred_upos_cdn: {preferred_upos_cdn}")
                 else:
-                    logger.warning("Assigned UPOS endpoint was never seen before, something else might have changed, so will not modify it")
+                    logger.warning(f"Assigned UPOS endpoint {original_endpoint} was never seen before, something else might have changed, so will not modify it")
             return asyncio.run(upload(f, total_size, ret, tasks=tasks))
 
     async def cos(self, file, total_size, ret, chunk_size=10485760, tasks=3, internal=False):


### PR DESCRIPTION
目前虽然提供了上传线路的选择，但传入`lines`参数的时候能选择的只是模式（`upos`, `kodo`, `cos`），即想选择UpOS模式下的线路（`bda2`, `qn`, `ws`）时不起作用，有可能的原因是在[preupload时只指定了模式却没有提及具体的线路](https://github.com/biliup/biliup/blob/41a8059785410ac09dbefb8c5a6e6783d4eede8e/biliup/plugins/bili_webup.py#L380C13-L391C27)

preupload结果提供的多个`endpoints`能说明在这几个CDN之间应该是能任意切换的
![DevTools Screenshot](https://github.com/biliup/biliup/assets/86680163/49c9c719-5914-4c8d-981f-8362e68c7e4d)
