### PR TITLE
在数据库中添加视频文件表

### DIFF
--- a/biliup/__main__.py
+++ b/biliup/__main__.py
@@ -55,6 +55,8 @@ def arg_parser():
 
 async def main(args):
     from .handler import event_manager
+    # 初始化数据库
+    db.init()
 
     event_manager.start()
 
@@ -63,8 +65,6 @@ async def main(args):
         # 这里也无需使用异步方法 一个线程一个检测 异步方法让渡控制权没用
         threading.Thread(target=check_url, args=(event_manager.context['checker'][plugin],)).start()
 
-    # 初始化数据库
-    db.init()
     # 启动时删除临时文件夹
     shutil.rmtree('./cache/temp', ignore_errors=True)
 

--- a/biliup/database/db.py
+++ b/biliup/database/db.py
@@ -1,6 +1,7 @@
 import time
 import json
 from datetime import datetime, timedelta
+from playhouse.shortcuts import model_to_dict
 
 from .models import StreamerInfo, FileList, db
 
@@ -40,6 +41,18 @@ class DB:
             res["date"] = datetime_to_struct_time(res["date"])
             return res
         return {}
+
+    @classmethod
+    def get_stream_info_by_filename(cls, filename: str) -> dict:
+        """通过文件名获取下载信息, 若不存在则返回空字典"""
+        with db.connection_context():
+            try:
+                stream_info = FileList.get(FileList.file == filename).streamer_info
+                stream_info_dict = model_to_dict(stream_info)
+                stream_info_dict["date"] = datetime_to_struct_time(stream_info_dict["date"])
+                return stream_info_dict
+            except FileList.DoesNotExist:
+                return {}
 
     @classmethod
     def add_stream_info(cls, name: str, url: str, title: str, date: time.struct_time) -> int:

--- a/biliup/database/db.py
+++ b/biliup/database/db.py
@@ -1,14 +1,17 @@
 import time
-from datetime import datetime
+import json
+from datetime import datetime, timedelta
 
-from .models import StreamerInfo, db
+from .models import StreamerInfo, FileList, db
 
 
 def struct_time_to_datetime(date: time.struct_time):
     return datetime.fromtimestamp(time.mktime(date))
 
+
 def datetime_to_struct_time(date: datetime):
     return time.localtime(date.timestamp())
+
 
 class DB:
     """数据库交互类"""
@@ -17,6 +20,7 @@ class DB:
     def init(cls):
         """初始化数据库"""
         StreamerInfo.create_table_()
+        FileList.create_table_()
 
     @classmethod
     def connect(cls):
@@ -38,30 +42,55 @@ class DB:
         return {}
 
     @classmethod
-    def add_stream_info(cls, name: str, url: str, title: str, date: time.struct_time, live_cover_path: str) -> bool:
-        """添加下载信息"""
+    def add_stream_info(cls, name: str, url: str, title: str, date: time.struct_time) -> int:
+        """添加下载信息, 返回所添加行的 id """
         return StreamerInfo.add(
             name=name,
             url=url,
             title=title,
             date=struct_time_to_datetime(date),
-            live_cover_path=live_cover_path
         )
 
     @classmethod
     def delete_stream_info(cls, name: str) -> int:
-        """删除下载信息, 返回删除的行数, 若不存在则返回0"""
+        """根据 streamer 删除下载信息, 返回删除的行数, 若不存在则返回 0 """
         return StreamerInfo.delete_(name=name)
 
     @classmethod
-    def update_stream_info(cls, name: str, url: str, title: str, date: time.struct_time, live_cover_path: str):
-        """更新下载信息"""
-        return StreamerInfo.update(
-            url=url,
-            title=title,
-            date=struct_time_to_datetime(date),
-            live_cover_path=live_cover_path
-        ).where(StreamerInfo.name == name).execute()
+    def delete_stream_info_by_date(cls, name: str, date: time.struct_time) -> int:
+        """根据 streamer 和开播时间删除下载信息, 返回删除的行数, 若不存在则返回 0 """
+        start_datetime = struct_time_to_datetime(date)
+        with db.connection_context():
+            dq = StreamerInfo.delete().where(
+                (StreamerInfo.name == name) &
+                (StreamerInfo.date.between(  # 传入的开播时间前后一分钟内都可以匹配
+                    start_datetime - timedelta(minutes=1),
+                    start_datetime + timedelta(minutes=1)))
+            )
+            return dq.execute()
+
+    @classmethod
+    def update_cover_path(cls, database_row_id: int, live_cover_path: str):
+        """更新封面存储路径"""
+        with db.connection_context():
+            return StreamerInfo.update(
+                live_cover_path=live_cover_path
+            ).where(StreamerInfo.id == database_row_id).execute()
+
+    @classmethod
+    def update_file_list(cls, database_row_id: int, file_name: str) -> int:
+        """向视频文件列表中添加文件名"""
+        streamer_info = StreamerInfo.get_by_id_(database_row_id)
+        return FileList.add(
+            file=file_name,
+            streamer_info=streamer_info
+        )
+
+    @classmethod
+    def get_file_list(cls, database_row_id: int) -> list[str]:
+        """获取视频文件列表"""
+        file_list = StreamerInfo.get_by_id_(database_row_id).file_list
+        return [file.file for file in file_list]
 
     def backup(self):
         """备份数据库"""

--- a/biliup/database/db.py
+++ b/biliup/database/db.py
@@ -55,12 +55,11 @@ class DB:
                 return {}
 
     @classmethod
-    def add_stream_info(cls, name: str, url: str, title: str, date: time.struct_time) -> int:
+    def add_stream_info(cls, name: str, url: str, date: time.struct_time) -> int:
         """添加下载信息, 返回所添加行的 id """
         return StreamerInfo.add(
             name=name,
             url=url,
-            title=title,
             date=struct_time_to_datetime(date),
         )
 
@@ -88,6 +87,14 @@ class DB:
         with db.connection_context():
             return StreamerInfo.update(
                 live_cover_path=live_cover_path
+            ).where(StreamerInfo.id == database_row_id).execute()
+
+    @classmethod
+    def update_room_title(cls, database_row_id: int, title: str):
+        """更新直播标题"""
+        with db.connection_context():
+            return StreamerInfo.update(
+                title=title
             ).where(StreamerInfo.id == database_row_id).execute()
 
     @classmethod

--- a/biliup/database/db.py
+++ b/biliup/database/db.py
@@ -1,5 +1,4 @@
 import time
-import json
 from datetime import datetime, timedelta
 from playhouse.shortcuts import model_to_dict
 
@@ -35,7 +34,7 @@ class DB:
 
     @classmethod
     def get_stream_info(cls, name: str) -> dict:
-        """获取下载信息, 若不存在则返回空字典"""
+        """根据 streamer 获取下载信息, 若不存在则返回空字典"""
         res = StreamerInfo.get_dict(name=name)
         if res:
             res["date"] = datetime_to_struct_time(res["date"])
@@ -49,10 +48,11 @@ class DB:
             try:
                 stream_info = FileList.get(FileList.file == filename).streamer_info
                 stream_info_dict = model_to_dict(stream_info)
-                stream_info_dict["date"] = datetime_to_struct_time(stream_info_dict["date"])
-                return stream_info_dict
             except FileList.DoesNotExist:
                 return {}
+        stream_info_dict = {key: value for key, value in stream_info_dict.items() if value}  # 清除字典中的空元素
+        stream_info_dict["date"] = datetime_to_struct_time(stream_info_dict["date"])  # 将开播时间转回 struct_time 类型
+        return stream_info_dict
 
     @classmethod
     def add_stream_info(cls, name: str, url: str, date: time.struct_time) -> int:
@@ -61,6 +61,8 @@ class DB:
             name=name,
             url=url,
             date=struct_time_to_datetime(date),
+            title="",
+            live_cover_path="",
         )
 
     @classmethod

--- a/biliup/database/models.py
+++ b/biliup/database/models.py
@@ -56,7 +56,10 @@ class BaseModel(Model):
     def get_by_id_(cls, pk):
         """根据主键获取记录"""
         with db.connection_context():
-            return cls.get_by_id(pk)
+            try:
+                return cls.get_by_id(pk)
+            except cls.DoesNotExist:
+                return cls()  # 若不存在, 则返回一个空对象
 
     @classmethod
     def get_dict(cls, **kwargs):
@@ -66,7 +69,7 @@ class BaseModel(Model):
                 obj = cls.get(**kwargs)
                 return model_to_dict(obj)
             except cls.DoesNotExist:
-                return False
+                return {}
 
 
 class StreamerInfo(BaseModel):
@@ -74,9 +77,9 @@ class StreamerInfo(BaseModel):
     id = AutoField(primary_key=True)  # 自增主键
     name = CharField()  # streamer 名称
     url = CharField()  # 录制的 url
-    title = CharField(null=True)  # 直播标题
+    title = CharField()  # 直播标题
     date = DateTimeField()  # 开播时间
-    live_cover_path = CharField(null=True)  # 封面存储路径
+    live_cover_path = CharField()  # 封面存储路径
 
 
 class FileList(BaseModel):

--- a/biliup/database/models.py
+++ b/biliup/database/models.py
@@ -1,7 +1,10 @@
 from pathlib import Path
+import logging
 
 from peewee import CharField, DateTimeField, IntegrityError, ForeignKeyField, AutoField, Model, SqliteDatabase
 from playhouse.shortcuts import ReconnectMixin, model_to_dict
+
+logger = logging.getLogger('biliup')
 
 
 def get_path(*other):
@@ -88,3 +91,8 @@ class FileList(BaseModel):
     file = CharField()  # 文件名
     # 外键, 对应 StreamerInfo 中的下载信息, 且启用级联删除
     streamer_info = ForeignKeyField(StreamerInfo, backref='file_list', on_delete='CASCADE')
+
+
+class TempStreamerInfo(StreamerInfo):
+    class Meta:
+        table_name = 'temp_streamer_info'

--- a/biliup/database/models.py
+++ b/biliup/database/models.py
@@ -74,9 +74,9 @@ class StreamerInfo(BaseModel):
     id = AutoField(primary_key=True)  # 自增主键
     name = CharField()  # streamer 名称
     url = CharField()  # 录制的 url
-    title = CharField()  # 直播标题
+    title = CharField(null=True)  # 直播标题
     date = DateTimeField()  # 开播时间
-    live_cover_path = CharField()  # 封面存储路径
+    live_cover_path = CharField(null=True)  # 封面存储路径
 
 
 class FileList(BaseModel):

--- a/biliup/database/models.py
+++ b/biliup/database/models.py
@@ -31,7 +31,7 @@ class BaseModel(Model):
     @classmethod
     def add(cls, **kwargs) -> int:
         """添加行, 返回添加的行的 id 值"""
-        with db.connection_context():
+        with db.atomic():
             try:
                 dq = cls.create(**kwargs)
                 return dq.id
@@ -41,7 +41,7 @@ class BaseModel(Model):
     @classmethod
     def delete_(cls, **kwargs):
         """删除行"""
-        with db.connection_context():
+        with db.atomic():
             try:
                 query = cls.get(**kwargs)
                 return query.delete_instance()
@@ -51,7 +51,7 @@ class BaseModel(Model):
     @classmethod
     def create_table_(cls):
         """创建表"""
-        with db.connection_context():
+        with db.atomic():
             if not cls.table_exists():
                 cls.create_table()
 

--- a/biliup/database/models.py
+++ b/biliup/database/models.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from peewee import CharField, DateTimeField, IntegrityError, Model, SqliteDatabase
+from peewee import CharField, DateTimeField, IntegrityError, ForeignKeyField, AutoField, Model, SqliteDatabase
 from playhouse.shortcuts import ReconnectMixin, model_to_dict
 
 
@@ -12,25 +12,28 @@ def get_path(*other):
         dir_path.mkdir(parents=True)
     return str(dir_path.joinpath(*other))
 
+
 # 自动重连, 避免报错导致连接丢失
 class ReconnectSqliteDatabase(ReconnectMixin, SqliteDatabase):
     pass
 
+
 db = ReconnectSqliteDatabase(f"{get_path('data.sqlite3')}")
+
 
 class BaseModel(Model):
     class Meta:
         database = db
 
     @classmethod
-    def add(cls, **kwargs):
-        """添加行"""
+    def add(cls, **kwargs) -> int:
+        """添加行, 返回添加的行的 id 值"""
         with db.connection_context():
             try:
-                cls.create(**kwargs)
-                return True
+                dq = cls.create(**kwargs)
+                return dq.id
             except IntegrityError:
-                return False
+                return 0
 
     @classmethod
     def delete_(cls, **kwargs):
@@ -50,6 +53,12 @@ class BaseModel(Model):
                 cls.create_table()
 
     @classmethod
+    def get_by_id_(cls, pk):
+        """根据主键获取记录"""
+        with db.connection_context():
+            return cls.get_by_id(pk)
+
+    @classmethod
     def get_dict(cls, **kwargs):
         """获取字典类型的数据"""
         with db.connection_context():
@@ -59,9 +68,20 @@ class BaseModel(Model):
             except cls.DoesNotExist:
                 return False
 
+
 class StreamerInfo(BaseModel):
-    name = CharField(primary_key=True)
-    url = CharField()
-    title = CharField()
-    date = DateTimeField()
-    live_cover_path = CharField()
+    """下载信息"""
+    id = AutoField(primary_key=True)  # 自增主键
+    name = CharField()  # streamer 名称
+    url = CharField()  # 录制的 url
+    title = CharField()  # 直播标题
+    date = DateTimeField()  # 开播时间
+    live_cover_path = CharField()  # 封面存储路径
+
+
+class FileList(BaseModel):
+    """存储文件名列表, 通过外键和 StreamerInfo 表关联"""
+    id = AutoField(primary_key=True)  # 自增主键
+    file = CharField()  # 文件名
+    # 外键, 对应 StreamerInfo 中的下载信息, 且启用级联删除
+    streamer_info = ForeignKeyField(StreamerInfo, backref='file_list', on_delete='CASCADE')

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -175,8 +175,9 @@ class DownloadBase:
         if not self.check_stream():
             return False
         file_name = self.file_name
-        # 将文件名存储到数据库
+        # 将文件名和直播标题存储到数据库
         db.update_file_list(self.database_row_id, file_name)
+        db.update_room_title(self.database_row_id, self.room_title)
         retval = self.download(file_name)
         self.rename(f'{file_name}.{self.suffix}')
         return retval
@@ -196,7 +197,6 @@ class DownloadBase:
         stream_info = {
             'name': self.fname,
             'url': self.url,
-            'title': self.room_title,
             'date': date,
         }
         self.database_row_id = db.add_stream_info(**stream_info)  # 返回数据库中此行记录的 id

--- a/biliup/engine/upload.py
+++ b/biliup/engine/upload.py
@@ -142,9 +142,10 @@ class UploadBase:
                 if len(file_list) > 0:
                     upload_filename_list = [os.path.splitext(file.video)[0] for file in file_list]
                     if ("title" not in self.data) or (not self.data["title"]):  # 如果 data 中不存在标题, 说明下载信息已丢失, 则尝试从数据库获取
-                        self.data.update(fmt_title_and_desc({
+                        data, _ = fmt_title_and_desc({
                             **db.get_stream_info_by_filename(upload_filename_list[0]),
-                            "name": self.principal}))  # 如果 restart, data 中会缺失 name 项
+                            "name": self.principal})  # 如果 restart, data 中会缺失 name 项
+                        self.data.update(data)
                     logger.info('准备上传' + self.data["format_title"])
                     with NamedLock('upload_filename'):
                         event_manager.context['upload_filename'].extend(upload_filename_list)

--- a/biliup/engine/upload.py
+++ b/biliup/engine/upload.py
@@ -140,9 +140,12 @@ class UploadBase:
                     file_list = UploadBase.file_list(self.principal)
 
                 if len(file_list) > 0:
-                    logger.info('准备上传' + self.data["format_title"])
                     upload_filename_list = [os.path.splitext(file.video)[0] for file in file_list]
-                    self.data.update(fmt_title_and_desc(db.get_stream_info_by_filename(upload_filename_list[0])))
+                    if ("title" not in self.data) or (not self.data["title"]):  # 如果 data 中不存在标题, 说明下载信息已丢失, 则尝试从数据库获取
+                        self.data.update(fmt_title_and_desc({
+                            **db.get_stream_info_by_filename(upload_filename_list[0]),
+                            "name": self.principal}))  # 如果 restart, data 中会缺失 name 项
+                    logger.info('准备上传' + self.data["format_title"])
                     with NamedLock('upload_filename'):
                         event_manager.context['upload_filename'].extend(upload_filename_list)
                     lock.release()

--- a/biliup/engine/upload.py
+++ b/biliup/engine/upload.py
@@ -148,6 +148,8 @@ class UploadBase:
                     needed2process = self.upload(file_list)
                     if needed2process:
                         self.postprocessor(needed2process)
+                if db.delete_stream_info_by_date(self.principal, self.data.get('date')) == 0:
+                    # 如果按开播时间删除失败，则尝试按照 streamer 删除
                     db.delete_stream_info(self.principal)
         finally:
             with NamedLock('upload_filename'):

--- a/biliup/engine/upload.py
+++ b/biliup/engine/upload.py
@@ -11,7 +11,7 @@ from typing import NamedTuple, Optional, List
 
 from biliup.common.tools import NamedLock
 from biliup.config import config
-
+from biliup.uploader import fmt_title_and_desc
 from biliup.database import DB as db
 
 logger = logging.getLogger('biliup')
@@ -142,6 +142,7 @@ class UploadBase:
                 if len(file_list) > 0:
                     logger.info('准备上传' + self.data["format_title"])
                     upload_filename_list = [os.path.splitext(file.video)[0] for file in file_list]
+                    self.data.update(fmt_title_and_desc(db.get_stream_info_by_filename(upload_filename_list[0])))
                     with NamedLock('upload_filename'):
                         event_manager.context['upload_filename'].extend(upload_filename_list)
                     lock.release()

--- a/biliup/engine/upload.py
+++ b/biliup/engine/upload.py
@@ -142,10 +142,12 @@ class UploadBase:
                 if len(file_list) > 0:
                     upload_filename_list = [os.path.splitext(file.video)[0] for file in file_list]
                     if ("title" not in self.data) or (not self.data["title"]):  # 如果 data 中不存在标题, 说明下载信息已丢失, 则尝试从数据库获取
-                        data, _ = fmt_title_and_desc({
+                        data, context = fmt_title_and_desc({
                             **db.get_stream_info_by_filename(upload_filename_list[0]),
                             "name": self.principal})  # 如果 restart, data 中会缺失 name 项
                         self.data.update(data)
+                        if hasattr(self, "description"):
+                            self.description = context.get('description', '')
                     logger.info('准备上传' + self.data["format_title"])
                     with NamedLock('upload_filename'):
                         event_manager.context['upload_filename'].extend(upload_filename_list)

--- a/biliup/uploader.py
+++ b/biliup/uploader.py
@@ -3,7 +3,6 @@ import logging
 import time
 
 from biliup.config import config
-from biliup.database import DB as db
 from .engine.decorators import Plugin
 
 logger = logging.getLogger('biliup')
@@ -18,8 +17,6 @@ def upload(data):
     """
     try:
         index = data['name']
-        # 尝试获取数据库中对应的数据, 并降低旧数据误用的可能性
-        data = {**db.get_stream_info(index), **data}
         context = {**config, **config['streamers'][index]}
         platform = context.get("uploader", "biliup-rs")
         cls = Plugin.upload_plugins.get(platform)

--- a/biliup/uploader.py
+++ b/biliup/uploader.py
@@ -22,7 +22,7 @@ def upload(data):
         cls = Plugin.upload_plugins.get(platform)
         if cls is None:
             return logger.error(f"No such uploader: {platform}")
-        data = fmt_title_and_desc(data)
+        data, context = fmt_title_and_desc(data)
         data['dolby'] = config.get('dolby', 0)
         data['hires'] = config.get('hires', 0)
         data['no_reprint'] = config.get('no_reprint', 0)
@@ -50,7 +50,7 @@ def fmt_title_and_desc(data):
     data["format_title"] = custom_fmtstr(context.get('title', f'%Y.%m.%d{index}'), date, title, streamer, url)
     if context.get('description'):
         context['description'] = custom_fmtstr(context.get('description'), date, title, streamer, url)
-    return data
+    return data, context
 
 
 def custom_fmtstr(string, date, title, streamer, url):

--- a/biliup/uploader.py
+++ b/biliup/uploader.py
@@ -25,14 +25,7 @@ def upload(data):
         cls = Plugin.upload_plugins.get(platform)
         if cls is None:
             return logger.error(f"No such uploader: {platform}")
-        streamer = data.get('streamer', index)
-        date = data.get("date", time.localtime())
-        title = data.get('title', index)
-        url = data.get('url')
-        live_cover_path = data.get('live_cover_path')
-        data["format_title"] = custom_fmtstr(context.get('title', f'%Y.%m.%d{index}'), date, title, streamer, url)
-        if context.get('description'):
-            context['description'] = custom_fmtstr(context.get('description'), date, title, streamer, url)
+        data = fmt_title_and_desc(data)
         data['dolby'] = config.get('dolby', 0)
         data['hires'] = config.get('hires', 0)
         data['no_reprint'] = config.get('no_reprint', 0)
@@ -46,6 +39,21 @@ def upload(data):
         return cls(index, data, **kwargs).start()
     except:
         logger.exception("Uncaught exception:")
+
+
+# 将格式化标题和简介拆分出来方便复用
+def fmt_title_and_desc(data):
+    index = data['name']
+    context = {**config, **config['streamers'][index]}
+    streamer = data.get('streamer', index)
+    date = data.get("date", time.localtime())
+    title = data.get('title', index)
+    url = data.get('url')
+    live_cover_path = data.get('live_cover_path')
+    data["format_title"] = custom_fmtstr(context.get('title', f'%Y.%m.%d{index}'), date, title, streamer, url)
+    if context.get('description'):
+        context['description'] = custom_fmtstr(context.get('description'), date, title, streamer, url)
+    return data
 
 
 def custom_fmtstr(string, date, title, streamer, url):


### PR DESCRIPTION
### 改动
- 在数据库中增加一个表存储视频文件名，并通过外键与原下载信息表关联
- 在开始下载之前存储下载信息，保证在下载中断的情况下仍然可以获取直播标题、开播时间

### Todo
- [x] 通过上传文件的文件名判断对应哪行下载信息
- [x] 实现旧数据库兼容/自动迁移
- [x] 测试