### PR TITLE
修复一些程序崩溃问题

### DIFF
--- a/biliup/config.py
+++ b/biliup/config.py
@@ -46,7 +46,7 @@ class Config(UserDict):
     def save_to_db(self):
         with db.connection_context():
             for k, v in self['streamers'].items():
-                us = UploadStreamers(template_name=k, tags=','.join(v.pop('tags', '')), **v)
+                us = UploadStreamers(template_name=k, tags=','.join(v.pop('tags', 'biliup')), **v)
                 us.save()
                 for url in v.pop('url'):
                     LiveStreamers(upload_streamers=us, remark=k, url=url, **v).save()

--- a/biliup/config.py
+++ b/biliup/config.py
@@ -46,7 +46,7 @@ class Config(UserDict):
     def save_to_db(self):
         with db.connection_context():
             for k, v in self['streamers'].items():
-                us = UploadStreamers(template_name=k, tags=','.join(v.pop('tags')), **v)
+                us = UploadStreamers(template_name=k, tags=','.join(v.pop('tags', '')), **v)
                 us.save()
                 for url in v.pop('url'):
                     LiveStreamers(upload_streamers=us, remark=k, url=url, **v).save()

--- a/public/config.toml
+++ b/public/config.toml
@@ -319,6 +319,7 @@ interval = 1
 backupCount = 1
 filename = "ds_update.log"
 formatter = "verbose"
+encoding = "utf-8"
 
 [LOGGING.root]
 handlers = [ "console" ]

--- a/public/config.yaml
+++ b/public/config.yaml
@@ -314,6 +314,7 @@ LOGGING:
             backupCount: 1
             filename: ds_update.log
             formatter: verbose
+            encoding: utf-8
     root:
         handlers: [ console ]
         level: INFO


### PR DESCRIPTION
1. 当配置中不包含 tag 时抛出 KeyError
2. 在日语系统中默认 log 配置会在写入 log 时抛出 cp932 字符相关 Error