### PR TITLE
Fix: config配置持久化导致的丢失format、uploader获取异常问题

### DIFF
--- a/biliup/database/models.py
+++ b/biliup/database/models.py
@@ -118,6 +118,7 @@ class UploadStreamers(BaseModel):
     uploader = CharField(null=True)  # 覆盖全局默认上传插件，Noop为不上传，但会执行后处理
     user_cookie = CharField(null=True)  # 使用指定的账号上传
     tags = CharField()
+    format = CharField(null=True)  # 视频保存格式,默认为flv
 
 class LiveStreamers(BaseModel):
     """每个直播间的配置"""

--- a/biliup/uploader.py
+++ b/biliup/uploader.py
@@ -18,7 +18,7 @@ def upload(data):
     try:
         index = data['name']
         context = {**config, **config['streamers'][index]}
-        platform = context.get("uploader", "biliup-rs")
+        platform = context.get("uploader") if context.get("uploader") else "biliup-rs"
         cls = Plugin.upload_plugins.get(platform)
         if cls is None:
             return logger.error(f"No such uploader: {platform}")


### PR DESCRIPTION
修复了以下两个问题:
1.  持久化配置时丢失了streamer配置中的format项，录制内容始终为flv
2. streamer配置中没有uploader项时，uploader始终为None导致无法上传