### PR TITLE
使用yt-dlp下载twitch回放，增加twitch等待下播后才下载最新回放功能

### DIFF
--- a/biliup/plugins/twitch.py
+++ b/biliup/plugins/twitch.py
@@ -1,26 +1,15 @@
-import random
 import re
-import subprocess
-import time
-from typing import Generator, List
-from urllib.parse import urlencode
-
-import requests
 import yt_dlp
+import requests
 
 from . import logger
 from ..engine.decorators import Plugin
 from ..engine.download import DownloadBase
 from biliup.config import config
-from biliup.plugins.Danmaku import DanmakuClient
 
-VALID_URL_BASE = r'(?:https?://)?(?:(?:www|go|m)\.)?twitch\.tv/(?P<id>[0-9_a-zA-Z]+)'
 VALID_URL_VIDEOS = r'https?://(?:(?:www|go|m)\.)?twitch\.tv/(?P<id>[^/]+)/(?:videos|profile|clips)'
 _CLIENT_ID = 'kimne78kx3ncx6brgo4mv6wki5h1ko'
-
-# Twitch 授权信息是否到期
 AUTH_EXPIRE_STATUS = False
-
 
 @Plugin.download(regexp=VALID_URL_VIDEOS)
 class TwitchVideos(DownloadBase):
@@ -29,7 +18,10 @@ class TwitchVideos(DownloadBase):
         self.is_download = True
 
     def check_stream(self, is_check=False):
-        # TODO 这里原本的批量检测是有问题的 先用yt_dlp实现 等待后续新增新的批量检测方式 后续这里的auth信息和直播一样采用twitch_cookie
+        if self._is_live():
+            logger.warning(f"{self.url}：主播正在直播，停止下载回放")
+            return False
+
         with yt_dlp.YoutubeDL({'download_archive': 'archive.txt'}) as ydl:
             try:
                 info = ydl.extract_info(self.url, download=False, process=False)
@@ -45,143 +37,46 @@ class TwitchVideos(DownloadBase):
                             self.live_cover_url = thumbnails[len(thumbnails) - 1].get('url')
                         ydl.record_download_archive(entry)
                     return True
-            except:
-                logger.warning(f"{self.url}：获取错误")
+            except Exception as e:
+                logger.warning(f"{self.url}：获取错误 - {e}")
                 return False
         return False
 
-
-
-@Plugin.download(regexp=VALID_URL_BASE)
-class Twitch(DownloadBase):
-    def __init__(self, fname, url, suffix='flv'):
-        DownloadBase.__init__(self, fname, url, suffix=suffix)
-        self.twitch_danmaku = config.get('twitch_danmaku', False)
-        self.twitch_disable_ads = config.get('twitch_disable_ads', True)
-        self.proc = None
-
-    def check_stream(self, is_check=False):
-        channel_name = re.match(VALID_URL_BASE, self.url).group('id').lower()
-        user = post_gql({
+    def _is_live(self):
+        channel_name = re.match(VALID_URL_VIDEOS, self.url).group('id').lower()
+        response = post_gql({
             "query": '''
                 query query($channel_name:String!) {
                     user(login: $channel_name){
                         stream {
-                            id
-                            title
                             type
-                            previewImageURL(width: 0,height: 0)
-                            playbackAccessToken(
-                                params: {
-                                    platform: "web",
-                                    playerBackend: "mediaplayer",
-                                    playerType: "site"
-                                }
-                            ) {
-                                signature
-                                value             
-                            }
                         }
                     }
                 }
             ''',
             'variables': {'channel_name': channel_name}
-        }).get('data', {}).get('user')
-        if not user:
-            logger.warning(f"{Twitch.__name__}: {self.url}: 获取错误")
-            return False
-        elif not user['stream'] or user['stream']['type'] != 'live':
-            return False
+        })
+        user = response.get('data', {}).get('user')
+        return user and user['stream'] and user['stream']['type'] == 'live'
 
-        self.room_title = user['stream']['title']
-        self.live_cover_url = user['stream']['previewImageURL']
-        if is_check:
-            return True
+    def download(self, filename):
+        download_dir = './downloads'
+        ydl_opts = {
+            'outtmpl': os.path.join(download_dir, f'{filename}.%(ext)s'),
+            'format': 'bestvideo+bestaudio/best',
+        }
 
-        if self.downloader == 'ffmpeg':
-            port = random.randint(1025, 65535)
-            stream_shell = [
-                "streamlink",
-                "--player-external-http",  # 为外部程序提供流媒体数据
-                # "--twitch-disable-ads",                     # 去广告，去掉、跳过嵌入的广告流
-                # "--twitch-disable-hosting",               # 该参数从5.0起已被禁用
-                "--twitch-disable-reruns",  # 如果该频道正在重放回放，不打开流
-                "--player-external-http-port", str(port),  # 对外部输出流的端口
-                self.url, "best"  # 流链接
-            ]
-            if self.twitch_disable_ads:  # 去广告，去掉、跳过嵌入的广告流
-                stream_shell.insert(1, "--twitch-disable-ads")
+        # 确保下载目录存在
+        if not os.path.exists(download_dir):
+            os.makedirs(download_dir)
 
-            twitch_cookie = config.get('user', {}).get('twitch_cookie')
-            # 在设置且有效的情况下使用
-            if twitch_cookie and not AUTH_EXPIRE_STATUS:
-                stream_shell.insert(1, "--twitch-api-header=Authorization=OAuth " + twitch_cookie)
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            ydl.download([self.raw_stream_url])
 
-            self.proc = subprocess.Popen(stream_shell)
-            self.raw_stream_url = f"http://localhost:{port}"
-            i = 0
-            while i < 5:
-                if not (self.proc.poll() is None):
-                    return False
-                time.sleep(1)
-                i += 1
-            return True
-        else:
-            query = {
-                "player": "twitchweb",
-                "p": random.randint(1000000, 10000000),
-                "allow_source": "true",
-                "allow_audio_only": "true",
-                "allow_spectre": "false",
-                'fast_bread': "true",
-                'sig': user.get('stream').get('playbackAccessToken').get('signature'),
-                'token': user.get('stream').get('playbackAccessToken').get('value'),
-            }
-            self.raw_stream_url = f'https://usher.ttvnw.net/api/channel/hls/{channel_name}.m3u8?{urlencode(query)}'
-            return True
-
-    @staticmethod
-    def batch_check(check_urls: List[str]) -> Generator[str, None, None]:
-        ops = []
-        for url in check_urls:
-            channel_name = re.match(VALID_URL_BASE, url).group('id')
-            op = {
-                "query": '''
-                    query query($login:String!) {
-                        user(login: $login){
-                            stream {
-                              type
-                            }
-                        }
-                    }
-                ''',
-                'variables': {'login': channel_name.lower()}
-            }
-            ops.append(op)
-        gql = post_gql(ops)
-        for index, data in enumerate(gql):
-            user = data.get('data', {}).get('user')
-            if not user:
-                logger.warning(f"{Twitch.__name__}: {check_urls[index]}: 获取错误")
-                continue
-            elif not user['stream'] or user['stream']['type'] != 'live':
-                continue
-            yield check_urls[index]
-
-    def danmaku_download_start(self, filename):
-        if self.twitch_danmaku:
-            self.danmaku = DanmakuClient(self.url, filename + "." + self.suffix)
-            self.danmaku.start()
-
-    def close(self):
-        if self.danmaku:
-            self.danmaku.stop()
-        try:
-            if self.proc is not None:
-                self.proc.terminate()
-        except:
-            logger.exception(f'terminate {self.fname} failed')
-
+        # 下载完成后，移动文件
+        for file in os.listdir(download_dir):
+            file_path = os.path.join(download_dir, file)
+            shutil.move(file_path, './')
 
 def post_gql(ops):
     global AUTH_EXPIRE_STATUS


### PR DESCRIPTION
GPT4写的，好像被删了下载弹幕的模块
直接使用yt-dlp来下载twitch的直播回放（参考了youtube.py）

主分支的twitch.py使用的是ffmpeg或者其他下载器下载，导致分段不正常。（如果使用ffmpeg下载的话，第一次分段后就不会下载后面的分段。使用stream-gear的话，可以正常分段，但是不会退出下载）

当主播直播时，将在下播后下载最新回放，防止下载最新回放不完整