### PR TITLE
Fix: 上传插件和简介艾特无法取消选择、分段大小单位错误

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -101,7 +101,7 @@ const Dashboard: React.FC = () => {
                         field='file_size'
                         extraText='录像单文件大小限制，单位Byte，超过此大小分段下载'
                         label={{text: "分段大小"} }
-                        suffix={'MB'}
+                        suffix={'Byte'}
                         style={{width: 250}}
                     />
             <Form.Input

--- a/app/ui/UserList.tsx
+++ b/app/ui/UserList.tsx
@@ -119,6 +119,7 @@ const UserList: React.FC<UserListProps> = ({onCancel, visible}) => {
                     field='value'
                     label="Cookie路径"
                     trigger='blur'
+                    placeholder='cookies.json'
                     rules={[
                         {required: true},
                     ]}

--- a/app/upload-manager/edit/page.tsx
+++ b/app/upload-manager/edit/page.tsx
@@ -77,8 +77,8 @@ const EditTemplate: React.FC = () => {
                         no_reprint: values?.no_reprint ? 1 : 0,
                         mission_id: values?.mission_id,
                         dtime: values?.isDtime ? values?.dtime : null,
-                        credits: values?.credits,
-                        uploader: values?.uploader,
+                        credits: values?.credits ?? null,
+                        uploader: values?.uploader ?? null,
                     }
                     const result = await trigger(studioEntity);
                     await mutate(result);

--- a/biliup/handler.py
+++ b/biliup/handler.py
@@ -36,7 +36,7 @@ def singleton_check(platform, name, url):
             yield Event(PRE_DOWNLOAD, args=(name, turl,))
         return
     if context['PluginInfo'].url_status[url] == 1:
-        logger.info(f'{url}-{url}-正在下载中，跳过检测')
+        logger.debug(f'{url}-{url}-正在下载中，跳过检测')
         return
     # 可能对同一个url同时发送两次上传事件
     with NamedLock(f"upload_count_{url}"):


### PR DESCRIPTION
修复：
- 上传插件、简介艾特不能改回空值
- 空间配置分段大小单位错误
- 更改“正在下载中”日志等级为`DEBUG`
- 添加`cookies`文件路径填写提示

Fixes #795 , fixes #797