### PR TITLE
修复码率类型错误、部分选项默认开启、投稿标签添加限制

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -247,7 +247,7 @@ tctc-h5（备用线路4）, tct-h5（备用线路5）, ali-h5（备用线路6）
                 label="youtube_max_videosize"
                 style={{width: 400}}
             />
-            <Form.Input
+            <Form.InputNumber
                 field="youtube_max_resolution"
                 extraText='设置偏好的YouTube下载最高纵向分辨率
 默认不限制

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -212,6 +212,7 @@ tctc-h5（备用线路4）, tct-h5（备用线路5）, ali-h5（备用线路6）
                 style={{width: 400}}
             />
             <Form.Switch
+                initValue={entity?.hasOwnProperty('youtube_enable_download_live') ? entity['youtube_enable_download_live'] : true}
                 field="youtube_enable_download_live"
                 extraText='### 是否下载直播 默认开启
 关闭后将忽略直播下载（可以下载回放） 避免网络被风控(有些网络只能下载回放无法下载直播)的时候还会尝试下载直播
@@ -223,6 +224,7 @@ tctc-h5（备用线路4）, tct-h5（备用线路5）, ali-h5（备用线路6）
                 label="youtube_enable_download_live"
             />
             <Form.Switch
+                initValue={entity?.hasOwnProperty('youtube_enable_download_playback') ? entity['youtube_enable_download_playback'] : true}
                 field="youtube_enable_download_playback"
                 extraText='是否下载直播回放 默认开启
 关闭后将忽略直播下载回放(不会影响正常的视频下载) 只想录制直播的可以开启
@@ -283,6 +285,7 @@ bilibili支持 mp4 mkv webm 无需筛选也能上传
                 label="twitch_danmaku"
             />
             <Form.Switch
+                initValue={entity?.hasOwnProperty('twitch_disable_ads') ? entity['twitch_disable_ads'] : true}
                 field="twitch_disable_ads"
                 extraText='去除Twitch广告功能，默认开启【只有下载器为FFMPEG时才有效】
 这个功能会导致Twitch录播分段，因为遇到广告就自动断开了，这就是去广告。若需要录播完整一整段可以关闭这个，但是关了之后就会有紫色屏幕的CommercialTime

--- a/app/ui/TemplateFields.tsx
+++ b/app/ui/TemplateFields.tsx
@@ -1,7 +1,7 @@
 import React, {useState} from "react";
 import {FormFCChild} from "@douyinfe/semi-ui/lib/es/form";
 import {IconChevronDown, IconChevronUp, IconMinusCircle, IconPlusCircle } from "@douyinfe/semi-icons";
-import {Avatar, Button, Collapsible, Form, InputGroup, Space, Typography, ArrayField} from "@douyinfe/semi-ui";
+import {Avatar, Button, Collapsible, Form, InputGroup, Space, Typography, ArrayField, Notification} from "@douyinfe/semi-ui";
 import useSWR from "swr";
 import {BiliType, fetcher, StudioEntity} from "../lib/api-streamer";
 import {useBiliUsers, useTypeTree} from "../lib/use-streamers";
@@ -134,11 +134,33 @@ const TemplateFields: React.FC<FormFCChild> = ({ formState, formApi, values }) =
                     ]}
                 />
                 <TagInput
+                    max={12}
+                    maxLength={20}
                     field="tags"
                     label='标签'
+                    allowDuplicates={false}
                     placeholder='输入标签，Enter 确定'
                     onChange={v => console.log(v)}
                     style={{width: 560}}
+                    rules={[
+                        { required: true, message: 'Tag不能为空' },
+                    ]}
+                    onExceed={v => {
+                        Notification.warning({
+                            title: '标签输入错误',
+                            position: 'top',
+                            content: '标签数量不能超过12个',
+                            duration: 3,
+                        });
+                    }}
+                    onInputExceed={v => {
+                        Notification.warning({
+                            title: '标签输入错误',
+                            position: 'top',
+                            content: '单个标签字数不能超过20',
+                            duration: 3,
+                        });
+                    }}
                 />
                 <Input field='cover_path' label='视频封面' style={{width: 464}} placeholder='/cover/up.jpg'/>
                 <TextArea style={{maxWidth: 560}}


### PR DESCRIPTION
## 修改

- ytb纵向分辨率类型错误
- 部分选项默认开启，webui中默认显示关闭
- 在前端添加限制：投稿标签不能为空，且不能超过12个，单个标签不能超过20字。符合b站投稿要求

Fixes #808 