### PR TITLE
Fix: datetime被过滤、新建空间配置无法保存

### DIFF
--- a/biliup/database/models.py
+++ b/biliup/database/models.py
@@ -44,6 +44,9 @@ class BaseModel(DeclarativeBase):
         temp = copy.deepcopy(self.__dict__)  # 深复制避免对原数据影响
         result = dict()
         for key, value in temp.items():  # 遍历删除不能被 json 序列化的键值对
+            if isinstance(value, datetime):  # 特殊处理，保留 datetime
+                result[key] = value
+                continue
             try:
                 json.dumps(value)
                 result[key] = value

--- a/biliup/web/__init__.py
+++ b/biliup/web/__init__.py
@@ -395,17 +395,20 @@ async def users(request):
             select(Configuration).where(Configuration.key == 'config')
         ).scalar_one()
         record.value = json.dumps(json_data)
-        Session.commit()
+        Session.flush()
+        resp = record.as_dict()
         # to_save = Configuration(key='config', value=json.dumps(json_data), id=record.id)
     except NoResultFound:
         to_save = Configuration(key='config', value=json.dumps(json_data))
         # to_save.save()
         Session.add(to_save)
-        return web.json_response(to_save.as_dict())
+        Session.flush()
+        resp = to_save.as_dict()
     except MultipleResultsFound as e:
         return web.json_response({"status": 500, 'error': f"有多个空间配置同时存在: {e}"}, status=500)
+    Session.commit()
     config.load_from_db()
-    return web.json_response(record.as_dict())
+    return web.json_response(resp)
 
 
 @routes.post('/v1/dump')

--- a/biliup/web/__init__.py
+++ b/biliup/web/__init__.py
@@ -393,18 +393,18 @@ async def users(request):
         # record = Configuration.get(Configuration.key == 'config')
         record = Session.execute(
             select(Configuration).where(Configuration.key == 'config')
-        ).scalar_one()
+        ).scalar_one()  # 判断是否只有一行空间配置
         record.value = json.dumps(json_data)
         Session.flush()
         resp = record.as_dict()
         # to_save = Configuration(key='config', value=json.dumps(json_data), id=record.id)
-    except NoResultFound:
+    except NoResultFound:  # 如果数据库中没有空间配置行，新建
         to_save = Configuration(key='config', value=json.dumps(json_data))
         # to_save.save()
         Session.add(to_save)
         Session.flush()
         resp = to_save.as_dict()
-    except MultipleResultsFound as e:
+    except MultipleResultsFound as e:  # 如果有多行，报错
         return web.json_response({"status": 500, 'error': f"有多个空间配置同时存在: {e}"}, status=500)
     Session.commit()
     config.load_from_db()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     'importlib-resources; python_version<"3.9"',
     'tomli >= 1.1.0 ; python_version < "3.11"',
     'protobuf >= 4.23.0',
-    "SQLAlchemy>=2.0.27",
+    "SQLAlchemy>=2.0.0",
     "alembic>=1.12.1",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Fix:
- 数据库记录转化为字典对象时`datetime`类型的值被过滤
- 新建空间配置时缺少`Session.commit()`，导致无法保存