### PR TITLE
Fix: 超出连接池上限无法释放、webui中cookie文件显示错误

### DIFF
--- a/app/lib/use-streamers.ts
+++ b/app/lib/use-streamers.ts
@@ -32,15 +32,26 @@ export function useBiliUsers() {
     }
   
     const updateList = async (item: User) => {
-      const res = await fetcher(`/bili/space/myinfo?user=${item.value}`, undefined);
-      const pRes = await proxy(`/bili/proxy?url=${res.data.face}`);
-      const myBlob = await pRes.blob();
-  
-      return {
-        ...item,
-        name: res.data.name,
-        face: URL.createObjectURL(myBlob),
-      };
+      try {
+        const res = await fetcher(`/bili/space/myinfo?user=${item.value}`, undefined);
+        const pRes = await proxy(`/bili/proxy?url=${res.data.face}`);
+        const myBlob = await pRes.blob();
+    
+        return {
+          ...item,
+          name: res.data.name,
+          face: URL.createObjectURL(myBlob),
+        };
+      } catch (error) {
+        console.error(error);
+        const pRes = await proxy("/bili/proxy?url=https://i0.hdslb.com/bfs/face/member/noface.jpg");
+        const myBlob = await pRes.blob();
+        return {
+          ...item,
+          name: "Cookie已失效",
+          face: URL.createObjectURL(myBlob),
+        };
+      }
     };
   
     const updateData = async (data: User[]) => {

--- a/biliup/__main__.py
+++ b/biliup/__main__.py
@@ -50,6 +50,7 @@ def arg_parser():
         except FileNotFoundError:
             print(f'新版本不依赖配置文件,请访问 WebUI 修改配置')
     config.load_from_db()
+    db.remove()
     LOG_CONF.update(config.get('LOGGING', {}))
     if args.verbose:
         LOG_CONF['loggers']['biliup']['level'] = args.verbose

--- a/biliup/database/db.py
+++ b/biliup/database/db.py
@@ -48,6 +48,16 @@ class DB:
         return run or no_http
 
     @classmethod
+    def close(cls):
+        """ 关闭 Session, 释放连接到连接池 """
+        Session.close()
+
+    @classmethod
+    def remove(cls):
+        """ 释放连接, 并删除注册表中的 Session """
+        Session.remove()
+
+    @classmethod
     def get_stream_info(cls, name: str) -> dict:
         """根据 streamer 获取下载信息, 若不存在则返回空字典"""
         res = Session.execute(

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -186,6 +186,7 @@ class DownloadBase:
         # 将文件名和直播标题存储到数据库
         db.update_file_list(self.database_row_id, file_name)
         db.update_room_title(self.database_row_id, self.room_title)
+        db.close()
         retval = self.download(file_name)
         self.rename(f'{file_name}.{self.suffix}')
         return retval
@@ -208,6 +209,7 @@ class DownloadBase:
             'date': date,
         }
         self.database_row_id = db.add_stream_info(**stream_info)  # 返回数据库中此行记录的 id
+        db.close()
 
         while True:
             ret = False
@@ -264,6 +266,7 @@ class DownloadBase:
         self.download_cover(time.strftime(self.get_filename().encode("unicode-escape").decode(), date).encode().decode("unicode-escape"))
         # 更新数据库中封面存储路径
         db.update_cover_path(self.database_row_id, self.live_cover_path)
+        db.remove()
         logger.info(f'退出下载：{self.__class__.__name__} - {self.fname}')
         stream_info = {
             'name': self.fname,

--- a/biliup/handler.py
+++ b/biliup/handler.py
@@ -132,6 +132,7 @@ def process_upload(stream_info):
             data, _ = fmt_title_and_desc({
                 **DB.get_stream_info_by_filename(os.path.splitext(file_list[0].video)[0]),
                 "name": name})  # 如果 restart, data 中会缺失 name 项
+            DB.remove()
             stream_info.update(data)
         filelist = upload(stream_info)
         if filelist:

--- a/biliup/web/__init__.py
+++ b/biliup/web/__init__.py
@@ -422,15 +422,21 @@ async def dump_config(request):
 
 @routes.get('/bili/archive/pre')
 async def pre_archive(request):
-    path = 'cookies.json'
+    # path = 'cookies.json'
     # conf = Configuration.get_or_none(Configuration.key == 'bilibili-cookies')
-    conf = Session.scalars(
-        select(Configuration).where(Configuration.key == 'bilibili-cookies')).first()
-    if conf is not None:
+    confs = Session.scalars(
+        select(Configuration).where(Configuration.key == 'bilibili-cookies'))
+    # if conf is not None:
+    #     path = conf.value
+    for conf in confs:
         path = conf.value
-    config.load_cookies(path)
-    cookies = config.data['user']['cookies']
-    return web.json_response(BiliBili.tid_archive(cookies))
+        try:
+            config.load_cookies(path)
+            cookies = config.data['user']['cookies']
+            return web.json_response(BiliBili.tid_archive(cookies))
+        except:
+            continue
+    return web.json_response({"status": 500, 'error': "无可用 cookie 文件"}, status=500)
 
 
 @routes.get('/bili/space/myinfo')


### PR DESCRIPTION
- 增加几处显式释放连接
- 优化中间件关闭 Session
- 优化 `pre` 获取cookie文件方式
- 修复 WebUI 中cookie文件失效表现形式