### PR TITLE
修复排序错误

### DIFF
--- a/app/job/page.tsx
+++ b/app/job/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { AutoComplete, Layout, Nav, Spin, Table, Typography } from "@douyinfe/semi-ui";
-import { SortOrder } from "@douyinfe/semi-ui/lib/es/table/interface";
+import { SortOrder } from "@douyinfe/semi-ui/lib/es/table";
 import useSWR from "swr";
 import {fetcher, FileList} from "@/app/lib/api-streamer";
 import {
@@ -20,6 +20,7 @@ export default function Home() {
     }
     const { Text } = Typography;
     const ascendSort: SortOrder = "ascend";
+    const descendSort: SortOrder = "descend";
     const columns = [
         {
             title: '名称',
@@ -49,11 +50,14 @@ export default function Home() {
         {
             title: '更新日期',
             dataIndex: 'date',
-            defaultSortOrder: ascendSort,
             render: (text: any, record: any, index: any) => {
                 return (<>{humDate(text)}</>);
             },
-            sorter: (a: any, b: any) => (a.updateTime - b.updateTime > 0 ? 1 : -1),
+            defaultSortOrder: descendSort,
+            sorter: (a: any, b: any, order: any) => {
+                // 后端发来的似乎是时间戳，正常比较大小就好
+                return a.date - b.date
+            },
         },
     ];
     const expandRowRender = (record: any, index: number | undefined) => {

--- a/app/ui/TemplateFields.tsx
+++ b/app/ui/TemplateFields.tsx
@@ -103,7 +103,21 @@ const TemplateFields: React.FC<FormFCChild> = ({ formState, formApi, values }) =
                 ]} field="user_cookie" label={{ text: '投稿账号' }} style={{ width: 176 }} optionList={list} />
             </Section>
             <Section text={'基本设置'} >
-                <Input field='title' label='视频标题' style={{width: 464}} placeholder='稿件标题'/>
+                <Input
+                    field='title'
+                    label='视频标题'
+                    style={{ width: 464 }}
+                    placeholder='稿件标题'
+                    extraText={
+                        <div style={{fontSize: 14}}>
+                            {'\u007B'}streamer{'\u007D'}: 录播备注
+                        <br />
+                            {'\u007B'}title{'\u007D'}: 直播标题
+                        <br />
+                            %Y-%m-%d %H_%M_%S: 开始录制时的 年-月-日 时_分_秒
+                        </div>
+                    }
+                />
                 <RadioGroup
                     field="copyright"
                     label='类型'


### PR DESCRIPTION
- `/job` 页 `更新时间` 排序错误，现在是正确的默认按时间倒序。
- `/upload-manager/add` 页添加信息