### PR TITLE
feat: 添加YouTube下载设置代理链接选项

### DIFF
--- a/app/ui/plugins/youtube.tsx
+++ b/app/ui/plugins/youtube.tsx
@@ -117,6 +117,18 @@ bilibili支持 mp4 mkv webm 无需筛选也能上传
                         padding: 0,
                     }}
                 />
+                <Form.Input
+                    field="youtube_proxy_url"
+                    extraText="
+默认不使用代理
+添加代理例如：http://127.0.0.1:7890"
+                    label="YouTube下载使用的代理链接（youtube_proxy_url）"
+                    style={{ width: "100%" }}
+                    fieldStyle={{
+                        alignSelf: "stretch",
+                        padding: 0,
+                    }}
+                />
             </Collapse.Panel>
         </>
     );

--- a/biliup/plugins/youtube.py
+++ b/biliup/plugins/youtube.py
@@ -31,14 +31,20 @@ class Youtube(DownloadBase):
         self.youtube_enable_download_playback = config.get('youtube_enable_download_playback', True)
         # 需要下载的 url
         self.download_url = None
+        self.youtube_proxy_url = config.get('youtube_proxy_url')
 
     def check_stream(self, is_check=False):
-        with yt_dlp.YoutubeDL({
+        ydl_opts = {
             'download_archive': 'archive.txt',
             'cookiefile': self.youtube_cookie,
             'ignoreerrors': True,
             'extractor_retries': 0,
-        }) as ydl:
+        }
+
+        if self.youtube_proxy_url is not None:
+            ydl_opts['proxy'] = self.youtube_proxy_url
+
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             # 获取信息的时候不要过滤
             ydl_archive = copy.deepcopy(ydl.archive)
             ydl.archive = set()
@@ -148,6 +154,9 @@ class Youtube(DownloadBase):
             ydl_opts['format'] += "+bestaudio"
             if self.youtube_prefer_acodec is not None:
                 ydl_opts['format'] += f"[acodec~='^({self.youtube_prefer_acodec})']"
+            if self.youtube_proxy_url is not None:
+                ydl_opts['proxy'] = self.youtube_proxy_url
+
             # 不能由yt_dlp创建会占用文件夹
             if not os.path.exists(download_dir):
                 os.makedirs(download_dir)


### PR DESCRIPTION
- webui中加入代理链接设置项：youtube_proxy_url
- 添加：yt-dlp check和download使用代理链接