### PR TITLE
下载功能调整

### DIFF
--- a/app/ui/plugins/douyu.tsx
+++ b/app/ui/plugins/douyu.tsx
@@ -19,7 +19,7 @@ const Douyu: React.FC = () => {
                 />
                 <Form.Switch
                     field="douyu_danmaku"
-                    extraText="录制斗鱼弹幕，默认关闭【下载器为ffmpeg,streamlink时效果最优】"
+                    extraText="录制斗鱼弹幕，默认关闭"
                     label="录制弹幕（douyu_danmaku）"
                 />
                 <Form.Select

--- a/app/ui/plugins/global.tsx
+++ b/app/ui/plugins/global.tsx
@@ -61,7 +61,7 @@ const Global: React.FC = () => {
                     label="视频分段大小（file_size）"
                     extraText={
                         <div style={{ fontSize: "14px" }}>
-                            录像单文件大小限制，超过此大小分段下载
+                            录像单文件大小限制，超过此大小分段下载，下载回放时无法使用
                             <br />
                             单位：Byte，示例：4294967296（4GB）
                         </div>

--- a/app/ui/plugins/huya.tsx
+++ b/app/ui/plugins/huya.tsx
@@ -21,7 +21,7 @@ const Huya: React.FC = () => {
                 />
                 <Form.Switch
                     field="huya_danmaku"
-                    extraText="录制虎牙弹幕，默认关闭【下载器为ffmpeg,streamlink时效果最优】"
+                    extraText="录制虎牙弹幕，默认关闭"
                     label="录制弹幕（huya_danmaku）"
                 />
                 <Form.Input

--- a/app/ui/plugins/twitcasting.tsx
+++ b/app/ui/plugins/twitcasting.tsx
@@ -9,7 +9,7 @@ const TwitCasting: React.FC = () => {
             <Collapse.Panel header="TwitCasting" itemKey="twitcasting">
                 <Form.Switch
                     field="twitcasting_danmaku"
-                    extraText="录制TwitCasting弹幕，默认关闭【下载器为ffmpeg,streamlink时效果最优】"
+                    extraText="录制TwitCasting弹幕，默认关闭"
                     label="录制弹幕（twitcasting_danmaku）"
                 />
                 <Form.Input

--- a/app/ui/plugins/twitch.tsx
+++ b/app/ui/plugins/twitch.tsx
@@ -13,7 +13,7 @@ const Twitch: React.FC<Props> = (props) => {
             <Collapse.Panel header="Twitch" itemKey="twitch">
                 <Form.Switch
                     field="twitch_danmaku"
-                    extraText="录制Twitch弹幕，默认关闭【下载器为ffmpeg,streamlink时效果最优】"
+                    extraText="录制Twitch弹幕，默认关闭"
                     label="录制弹幕（twitch_danmaku）"
                 />
                 <Form.Switch
@@ -23,7 +23,7 @@ const Twitch: React.FC<Props> = (props) => {
                             : true
                     }
                     field="twitch_disable_ads"
-                    extraText="去除Twitch广告功能，默认开启【下载器为ffmpeg,streamlink时效果最优】
+                    extraText="去除Twitch广告功能，默认开启
 这个功能会导致Twitch录播分段，因为遇到广告就自动断开了，这就是去广告。若需要录播完整一整段可以关闭这个，但是关了之后就会有紫色屏幕的CommercialTime
 还有一个不想视频分段的办法是去花钱开一个Turbo会员，能不看广告，然后下面的user里把twitch的cookie填上，也能不看广告，自然就不会分段了"
                     label="去除广告（twitch_disable_ads）"

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -34,7 +34,7 @@ class DownloadBase(ABC):
         self.url = url
         # 录制后保存文件格式而非源流格式 对应原配置文件format 仅ffmpeg及streamlink生效
         if not suffix:
-            self.suffix = 'flv'
+            logger.error(f'检测到suffix不存在，请补充后缀')
         else:
             self.suffix = suffix.lower()
         self.live_cover_path = None
@@ -109,10 +109,9 @@ class DownloadBase(ABC):
         return True
 
     def ffmpeg_segment_download(self):
-        # TODO 无日志
         # ffmpeg 输入参数
         input_args = [
-            '-loglevel', 'quiet', '-y'
+            '-loglevel', 'quiet', '-report', '-y'
         ]
         # ffmpeg 输出参数
         output_args = [

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -412,7 +412,14 @@ class DownloadBase(ABC):
             filename = f'{self.fname}%Y-%m-%dT%H_%M_%S'
         filename = get_valid_filename(filename)
         if is_fmt:
-            return time.strftime(filename.encode("unicode-escape").decode()).encode().decode("unicode-escape")
+            file_time = time.time()
+            while True:
+                fmt_file_name = time.strftime(filename.encode("unicode-escape").decode(),
+                                              time.localtime(file_time)).encode().decode("unicode-escape")
+                if os.path.exists(f"{fmt_file_name}.{self.suffix}"):
+                    file_time += 1
+                else:
+                    return fmt_file_name
         else:
             return filename
 

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -2,11 +2,11 @@ import logging
 import os
 import re
 import subprocess
-import sys
+import threading
 import time
 import shutil
 from abc import ABC, abstractmethod
-from typing import Generator, List
+from typing import Generator, List, Callable
 from urllib.parse import urlparse
 
 import requests
@@ -37,7 +37,6 @@ class DownloadBase(ABC):
             logger.error(f'检测到suffix不存在，请补充后缀')
         else:
             self.suffix = suffix.lower()
-        self.title = None
         self.live_cover_path = None
         self.database_row_id = 0
         self.downloader = config.get('downloader', 'stream-gears')
@@ -47,8 +46,6 @@ class DownloadBase(ABC):
         self.filename_prefix = config.get('filename_prefix')
         self.use_live_cover = config.get('use_live_cover', False)
         self.opt_args = opt_args
-        # 是否是下载模式 跳过下播检测
-        self.is_download = False
         self.live_cover_url = None
         self.fake_headers = {
             'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
@@ -56,35 +53,19 @@ class DownloadBase(ABC):
             'accept-language': 'zh-CN,zh;q=0.8,en-US;q=0.5,en;q=0.3',
             'user-agent': random_user_agent(),
         }
+        self.segment_time = config.get('segment_time')
+        self.file_size = config.get('file_size')
 
-        self.default_output_args = [
-            '-bsf:a', 'aac_adtstoasc',
-        ]
-        if config.get('segment_time'):
-            # 处理一些奇怪的时间，例如 00:60:00 应该自动修正为 01:00:00； 00:300:60 应该自动修正为 05:01:00
-            # if ':' in config.get('segment_time', '00:50:00'):
-            #     segment_time = config.get('segment_time').split(':')
-            #     if len(segment_time) == 3:
-            #         if int(segment_time[2]) > 59:
-            #             extra_minutes, seconds = divmod(int(segment_time[2]), 60)
-            #             segment_time[2] = str(seconds)
-            #             segment_time[1] = str(int(segment_time[1]) + extra_minutes)
-            #         if int(segment_time[1]) > 59:
-            #             extra_hours, minutes = divmod(int(segment_time[1]), 60)
-            #             segment_time[1] = str(minutes)
-            #             segment_time[0] = str(int(segment_time[0]) + extra_hours)
-            #         segment_time = ':'.join(segment_time)
-            #         logger.info(f'修正了segment_time参数为 {segment_time}')
-            self.default_output_args += \
-                ['-to', f"{config.get('segment_time', '00:50:00')}"]
-        else:
-            self.default_output_args += \
-                ['-fs', f"{config.get('file_size', '2621440000')}"]
+        # 是否是下载模式 跳过下播检测
+        self.is_download = False
+
+        # 分段后处理
+        self.segment_processor = config.get('segment_processor')
+        self.segment_processor_thread = []
 
     @abstractmethod
     def check_stream(self, is_check=False):
-        # is_check 是否是检测可以避免在检测是否可以录制的时候忽略一些耗时的操作
-        logger.debug(self.fname, is_check)
+        # is_check 是否是检测模式 检测模式可以忽略只有下载时需要的耗时操作
         raise NotImplementedError()
 
     @staticmethod
@@ -93,36 +74,27 @@ class DownloadBase(ABC):
         # 返回的是url_list
         raise NotImplementedError()
 
-    def get_filename(self, is_fmt=False):
-        if self.filename_prefix:  # 判断是否存在自定义录播命名设置
-            filename = (self.filename_prefix.format(streamer=self.fname, title=self.room_title).encode(
-                'unicode-escape').decode()).encode().decode("unicode-escape")
-        else:
-            filename = f'{self.fname}%Y-%m-%dT%H_%M_%S'
-        filename = get_valid_filename(filename)
-        if is_fmt:
-            return time.strftime(filename.encode("unicode-escape").decode()).encode().decode("unicode-escape")
-        else:
-            return filename
-
-    def download(self, filename):
-        filename = self.get_filename()
-        fmtname = time.strftime(filename.encode("unicode-escape").decode()).encode().decode("unicode-escape")
-
-        self.danmaku_download_start(fmtname)
+    def download(self):
+        self.danmaku_download_start(self.__gen_download_filename())
+        if self.is_download:
+            if not shutil.which("ffmpeg"):
+                logger.error("未安装 FFMpeg 或不存在于 PATH 内")
+                logger.debug("Current user's PATH is:" + os.getenv("PATH"))
+                return False
+            else:
+                return self.ffmpeg_segment_download()
 
         parsed_url_path = urlparse(self.raw_stream_url).path
-        if shutil.which("ffmpeg"):
-            if self.downloader == 'streamlink':
-                if '.flv' in parsed_url_path:  # streamlink无法处理flv,所以回退到ffmpeg
-                    return self.ffmpeg_download(fmtname)
+        if self.downloader == 'streamlink' or self.downloader == 'ffmpeg':
+            if shutil.which("ffmpeg"):
+                # streamlink无法处理flv,所以回退到ffmpeg
+                if self.downloader == 'streamlink' and '.flv' in parsed_url_path:
+                    return self.ffmpeg_download(use_streamlink=True)
                 else:
-                    return self.streamlink_download(fmtname)
-            elif self.downloader == 'ffmpeg':
-                return self.ffmpeg_download(fmtname)
-        else:
-            logger.error("未安装 FFMpeg 或不存在于 PATH 内，本次下载使用 stream-gears")
-            logger.debug("Current user's PATH is:" + os.getenv("PATH"))
+                    return self.ffmpeg_download()
+            else:
+                logger.error("未安装 FFMpeg 或不存在于 PATH 内，本次下载使用 stream-gears")
+                logger.debug("Current user's PATH is:" + os.getenv("PATH"))
 
         if '.flv' in parsed_url_path:
             # 假定flv流
@@ -130,96 +102,156 @@ class DownloadBase(ABC):
         else:
             # 其他流stream_gears会按hls保存为ts
             self.suffix = 'ts'
-        stream_gears_download(self.raw_stream_url, self.fake_headers, filename, config.get('segment_time'),
-                              config.get('file_size'))
+        stream_gears_download(self.raw_stream_url, self.fake_headers, self.__gen_download_filename(),
+                              config.get('segment_time'),
+                              config.get('file_size'),
+                              lambda file_name: self.__download_segment_callback(file_name))
         return True
 
-    def streamlink_download(self, filename):  # streamlink+ffmpeg混合下载模式，适用于下载hls流
-        streamlink_input_args = ['--stream-segment-threads', '3', '--hls-playlist-reload-attempts', '1']
-        streamlink_cmd = ['streamlink', *streamlink_input_args, self.raw_stream_url, 'best', '-O']
-        ffmpeg_input_args = ['-rw_timeout', '20000000']
-        ffmpeg_cmd = ['ffmpeg', '-re', '-i', 'pipe:0', '-y', *ffmpeg_input_args, *self.default_output_args,
-                      *self.opt_args, '-c', 'copy', '-f', self.suffix]
-        # if config.get('segment_time'):
-        #     ffmpeg_cmd += ['-f', 'segment',
-        #              f'{filename} part-%03d.{self.suffix}']
-        # else:
-        #     ffmpeg_cmd += [
-        #         f'{filename}.{self.suffix}.part']
-        ffmpeg_cmd += [f'{filename}.{self.suffix}.part']
-        streamlink_proc = subprocess.Popen(streamlink_cmd, stdout=subprocess.PIPE)
-        ffmpeg_proc = subprocess.Popen(ffmpeg_cmd, stdin=streamlink_proc.stdout, stdout=subprocess.PIPE,
-                                       stderr=subprocess.STDOUT)
-        try:
-            with ffmpeg_proc.stdout as stdout:
-                for line in iter(stdout.readline, b''):
-                    decode_line = line.decode(errors='ignore')
-                    print(decode_line, end='', file=sys.stderr)
-                    logger.debug(decode_line.rstrip())
-            retval = ffmpeg_proc.wait()
-            streamlink_proc.terminate()
-            streamlink_proc.wait()
-        except KeyboardInterrupt:
-            if sys.platform != 'win32':
-                ffmpeg_proc.communicate(b'q')
-            raise
-        if retval != 0:
-            return False
-        return True
+    def ffmpeg_segment_download(self):
+        # ffmpeg 输入参数
+        input_args = [
+            '-loglevel', 'quiet', '-report', '-y'
+        ]
+        # ffmpeg 输出参数
+        output_args = [
+            '-bsf:a', 'aac_adtstoasc'
+        ]
+        input_args += ['-headers', ''.join('%s: %s\r\n' % x for x in self.fake_headers.items()),
+                       '-rw_timeout', '20000000']
+        if '.m3u8' in urlparse(self.raw_stream_url).path:
+            input_args += ['-max_reload', '1000']
 
-    def ffmpeg_download(self, filename):
-        default_input_args = ['-headers', ''.join('%s: %s\r\n' % x for x in self.fake_headers.items()),
-                              '-rw_timeout', '20000000']
-        parsed_url = urlparse(self.raw_stream_url)
-        path = parsed_url.path
-        if '.m3u8' in path:
-            default_input_args += ['-max_reload', '1000']
-        args = ['ffmpeg', '-y', *default_input_args,
-                '-i', self.raw_stream_url, *self.default_output_args, *self.opt_args,
-                '-c', 'copy', '-f', self.suffix]
-        # if config.get('segment_time'):
-        #     args += ['-f', 'segment',
-        #              f'{filename} part-%03d.{self.suffix}']
-        # else:
-        #     args += [
-        #         f'{filename}.{self.suffix}.part']
-        args += [f'{filename}.{self.suffix}.part']
+        input_args += ['-i', self.raw_stream_url]
 
-        proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        try:
-            with proc.stdout as stdout:
-                for line in iter(stdout.readline, b''):  # b'\n'-separated lines
-                    decode_line = line.decode(errors='ignore')
-                    print(decode_line, end='', file=sys.stderr)
-                    logger.debug(decode_line.rstrip())
-            retval = proc.wait()
-        except KeyboardInterrupt:
-            if sys.platform != 'win32':
-                proc.communicate(b'q')
-            raise
-        if retval != 0:
-            return False
-        return True
+        output_args += ['-f', 'segment']
+        # output_args += ['-segment_format', self.suffix]
+        output_args += ['-segment_list', 'pipe:1']
+        output_args += ['-segment_list_type', 'flat']
+        output_args += ['-reset_timestamps', '1']
+        # output_args += ['-strftime', '1']
+        if self.segment_time:
+            output_args += ['-segment_time', self.segment_time]
+        else:
+            # 避免适配两套
+            output_args += ['-segment_time', '9999:00:00']
 
-    def danmaku_download_start(self, filename):
+        output_args += ['-c', 'copy']
+        output_args += self.opt_args
+        args = ['ffmpeg', *input_args, *output_args, f'{self.fname}_{int(time.time() * 1e6)}_%d.{self.suffix}']
+        with subprocess.Popen(args, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                              stderr=subprocess.DEVNULL) as proc:
+            file_name = self.__gen_download_filename(is_fmt=True)
+            for line in iter(proc.stdout.readline, b''):  # b'\n'-separated lines
+                ffmpeg_file_name = line.rstrip().decode(errors='ignore')
+                time.sleep(1)
+                # 文件重命名
+                self.__download_file_rename(ffmpeg_file_name, f'{file_name}.{self.suffix}')
+                self.__download_segment_callback(f'{file_name}.{self.suffix}')
+                file_name = self.__gen_download_filename(is_fmt=True)
+
+        return proc.returncode == 0
+
+    def ffmpeg_download(self, use_streamlink=False):
+        while True:
+            # streamlink进程
+            streamlink_proc = None
+            try:
+                # 文件名不含后戳
+                fmt_file_name = self.__gen_download_filename(is_fmt=True)
+                # ffmpeg 输入参数
+                input_args = []
+                # ffmpeg 输出参数
+                output_args = [
+                    '-bsf:a', 'aac_adtstoasc',
+                ]
+                if use_streamlink:
+                    streamlink_cmd = ['streamlink', '--stream-segment-threads', '3', '--hls-playlist-reload-attempts',
+                                      '1',
+                                      self.raw_stream_url, 'best', '-O']
+                    streamlink_proc = subprocess.Popen(streamlink_cmd, stdout=subprocess.PIPE)
+                    input_uri = 'pipe:0'
+                else:
+                    input_args += ['-headers', ''.join('%s: %s\r\n' % x for x in self.fake_headers.items()),
+                                   '-rw_timeout', '20000000']
+                    if '.m3u8' in urlparse(self.raw_stream_url).path:
+                        input_args += ['-max_reload', '1000']
+                    input_uri = self.raw_stream_url
+
+                input_args += ['-i', input_uri]
+
+                if self.segment_time:
+                    output_args += ['-to', self.segment_time]
+                if self.file_size:
+                    output_args += ['-fs', self.file_size]
+
+                output_args += self.opt_args
+
+                args = ['ffmpeg', '-y', *input_args, *output_args, '-c', 'copy', '-f', self.suffix,
+                        f'{fmt_file_name}.{self.suffix}.part']
+                with subprocess.Popen(args, stdin=subprocess.DEVNULL if not streamlink_proc else streamlink_proc.stdout,
+                                      stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as proc:
+                    for line in iter(proc.stdout.readline, b''):  # b'\n'-separated lines
+                        decode_line = line.rstrip().decode(errors='ignore')
+                        print(decode_line)
+                        logger.debug(decode_line)
+
+                if proc.returncode == 0:
+                    # 文件重命名
+                    self.__download_file_rename(f'{fmt_file_name}.{self.suffix}.part', f'{fmt_file_name}.{self.suffix}')
+                    # 触发分段事件
+                    self.__download_segment_callback(f'{fmt_file_name}.{self.suffix}')
+
+                    if not self.check_stream():
+                        return False
+                else:
+                    return False
+            finally:
+                if streamlink_proc:
+                    streamlink_proc.terminate()
+
+    def __download_segment_callback(self, file_name: str):
+        """
+        分段后触发返回含后戳的文件名
+        """
+        exclude_ext_file_name = os.path.splitext(file_name)[0]
+        danmaku_file_name = exclude_ext_file_name + '.xml'
+        self.danmaku_segment(danmaku_file_name)
+        # 将文件名和直播标题存储到数据库
+        with SessionLocal() as db:
+            update_room_title(db, self.database_row_id, self.room_title)
+            update_file_list(db, self.database_row_id, file_name)
+        if self.segment_processor:
+            try:
+                from biliup.common.tools import processor
+                data = os.path.abspath(file_name)
+                if os.path.exists(danmaku_file_name):
+                    data += f'\n{os.path.abspath(danmaku_file_name)}'
+                thread = threading.Thread(target=processor, args=(self.segment_processor, data), daemon=True,
+                                          name=f"segment_processor_{exclude_ext_file_name}")
+                thread.start()
+                self.segment_processor_thread.append(thread)
+            except:
+                logger.warning(f'执行后处理失败：{self.__class__.__name__} - {self.fname}', exc_info=True)
+
+    def __download_success_callback(self):
         pass
 
     def run(self):
         if not self.check_stream():
             return False
-        file_name = self.file_name
-        # 将文件名和直播标题存储到数据库
         with SessionLocal() as db:
-            update_file_list(db, self.database_row_id, file_name)
             update_room_title(db, self.database_row_id, self.room_title)
-        retval = self.download(file_name)
-        self.rename(f'{file_name}.{self.suffix}')
+        retval = self.download()
         return retval
 
     def start(self):
-        logger.info(f'开始下载：{self.__class__.__name__} - {self.fname}')
-        date = time.localtime()
+        logger.info(f'开始下载: {self.__class__.__name__} - {self.fname}')
+        # 开始时间
+        start_time = time.localtime()
+        # 结束时间
         end_time = None
+        # 下播延迟检测
         delay = int(config.get('delay', 0))
         # 重试次数
         retry_count = 0
@@ -228,93 +260,74 @@ class DownloadBase(ABC):
         # delay 总重试次数 向上取整
         delay_all_retry_count = -(-delay // 60)
 
-        stream_info = {
-            'name': self.fname,
-            'url': self.url,
-            'date': date,
-        }
         with SessionLocal() as db:
-            self.database_row_id = add_stream_info(db, **stream_info)  # 返回数据库中此行记录的 id
+            self.database_row_id = add_stream_info(db, self.fname, self.url, start_time)  # 返回数据库中此行记录的 id
 
         while True:
+            # 下载结果
             ret = False
             try:
                 ret = self.run()
             except:
-                logger.exception('Uncaught exception:')
+                logger.warning(f'下载失败: {self.__class__.__name__} - {self.fname}', exc_info=True)
             finally:
                 self.close()
+
             if ret:
+                # 下载模式如果下载成功直接跳出
                 if self.is_download:
-                    try:
-                        segment_processor = config['streamers'].get(self.fname, {}).get('segment_processor')
-                        if segment_processor:
-                            from biliup.common.tools import processor
-                            import multiprocessing as mp
-                            from biliup.database.db import get_file_list
-                            with SessionLocal() as db:
-                                file_name = get_file_list(db, self.database_row_id)[-1]
-                            segment_process = mp.get_context('spawn').Process(target=processor, daemon=True, kwargs=(segment_processor, os.path.abspath(f'{file_name}.{self.suffix}') + ('\n' + os.path.abspath(f'{file_name}.xml') if os.path.exists(os.path.abspath(f'{file_name}.xml')) else '')))
-                            segment_process.start()
-                    except:
-                        logger.exception('Uncaught exception:')
-                    # 成功下载后也不检测下一个需要下载的视频而是先上传等待下次检测保证上传时使用下载视频的标题
-                    # 开启边录边传会快些
                     break
                 # 成功下载重置重试次数
                 retry_count = 0
                 retry_count_delay = 0
+                # 最后一次下载完成时间
+                end_time = time.localtime()
             else:
-                if self.is_download:
-                    # 下载模式如果下载失败直接跳出
-                    break
-
                 if retry_count < 3:
                     retry_count += 1
                     logger.info(
-                        f'获取流失败：{self.__class__.__name__} - {self.fname}，重试次数 {retry_count} / 3，等待 10 秒')
+                        f'获取流失败: {self.__class__.__name__} - {self.fname}，重试次数 {retry_count} / 3，等待 10 秒')
                     time.sleep(10)
                     continue
 
-                if delay:
+                if delay and retry_count_delay < delay_all_retry_count:
                     retry_count_delay += 1
-                    if retry_count_delay > delay_all_retry_count:
-                        logger.info(f'下播延迟检测结束：{self.__class__.__name__}:{self.fname}')
-                        break
+                    if delay < 60:
+                        logger.info(
+                            f'下播延迟检测: {self.__class__.__name__} - {self.fname}，将在 {delay} 秒后检测开播状态')
+                        time.sleep(delay)
                     else:
-                        if delay < 60:
-                            logger.info(
-                                f'下播延迟检测：{self.__class__.__name__} - {self.fname}，将在 {delay} 秒后检测开播状态')
-                            time.sleep(delay)
-                        else:
-                            if retry_count_delay == 1:
-                                end_time = time.localtime()
-                                # 只有第一次显示
-                                logger.info(
-                                    f'下播延迟检测：{self.__class__.__name__} - {self.fname}，每隔 60 秒检测开播状态，共检测 {delay_all_retry_count} 次')
-                            time.sleep(60)
-                        continue
+                        logger.info(
+                            f'下播延迟检测: {self.__class__.__name__} - {self.fname}，每隔 60 秒检测开播状态，检测次数 {retry_count_delay} / {delay_all_retry_count}')
+                        time.sleep(60)
+                    continue
                 else:
-                    end_time = time.localtime()
+                    # 未设置下播延迟检测 or 下播检测次数已到
                     break
 
-        if end_time is None:
-            end_time = time.localtime()
-        self.download_cover(time.strftime(self.get_filename().encode("unicode-escape").decode(), date).encode().decode(
-            "unicode-escape"))
+        self.download_cover(
+            time.strftime(self.__gen_download_filename().encode("unicode-escape").decode(), start_time).encode().decode(
+                "unicode-escape"))
         # 更新数据库中封面存储路径
         with SessionLocal() as db:
             update_cover_path(db, self.database_row_id, self.live_cover_path)
-        logger.info(f'退出下载：{self.__class__.__name__} - {self.fname}')
+
+        for thread in self.segment_processor_thread:
+            if thread.is_alive():
+                logger.info(f'等待分段后处理完成: {self.__class__.__name__} - {self.fname} - {thread.name}')
+                thread.join()
+        if (self.is_download and ret) or not self.is_download:
+            self.__download_success_callback()
+        # self.segment_processor_thread
+        logger.info(f'退出下载: {self.__class__.__name__} - {self.fname}')
         stream_info = {
             'name': self.fname,
             'url': self.url,
             'title': self.room_title,
-            'date': date,
+            'date': start_time,
+            'end_time': end_time if end_time else time.localtime(),
             'live_cover_path': self.live_cover_path,
             'is_download': self.is_download,
-            # 内部使用时间戳传递
-            'end_time': end_time,
         }
         return stream_info
 
@@ -383,32 +396,40 @@ class DownloadBase(ABC):
             logger.debug(f"{e} from {url}")
         return False, None
 
-    @staticmethod
-    def rename(file_name):
-        try:
-            os.rename(file_name + '.part', file_name)
-            logger.info(f'更名 {file_name + ".part"} 为 {file_name}')
-        except FileNotFoundError:
-            logger.debug(f'文件不存在: {file_name}')
-        except FileExistsError:
-            os.rename(file_name + '.part', file_name)
-            logger.info(f'更名 {file_name + ".part"} 为 {file_name} 失败, {file_name} 已存在')
-
-    @property
-    def file_name(self):
+    def __gen_download_filename(self, is_fmt=False):
         if self.filename_prefix:  # 判断是否存在自定义录播命名设置
             filename = (self.filename_prefix.format(streamer=self.fname, title=self.room_title).encode(
                 'unicode-escape').decode()).encode().decode("unicode-escape")
         else:
             filename = f'{self.fname}%Y-%m-%dT%H_%M_%S'
         filename = get_valid_filename(filename)
-        return time.strftime(filename.encode("unicode-escape").decode()).encode().decode("unicode-escape")
+        if is_fmt:
+            return time.strftime(filename.encode("unicode-escape").decode()).encode().decode("unicode-escape")
+        else:
+            return filename
+
+    @staticmethod
+    def __download_file_rename(old_file_name, file_name):
+        try:
+            os.rename(old_file_name, file_name)
+            logger.info(f'更名 {old_file_name} 为 {file_name}')
+        except FileNotFoundError:
+            logger.debug(f'文件不存在: {old_file_name}')
+        except FileExistsError:
+            logger.info(f'更名 {old_file_name} 为 {file_name} 失败, {file_name} 已存在')
+
+    def danmaku_download_start(self, filename):
+        pass
+
+    def danmaku_segment(self, new_prev_file_name: str):
+        pass
 
     def close(self):
         pass
 
 
-def stream_gears_download(url, headers, file_name, segment_time=None, file_size=None):
+def stream_gears_download(url, headers, file_name, segment_time=None, file_size=None,
+                          file_name_callback: Callable[[str], None] = None):
     class Segment:
         pass
 
@@ -421,12 +442,21 @@ def stream_gears_download(url, headers, file_name, segment_time=None, file_size=
         segment.size = file_size
     if file_size is None and segment_time is None:
         segment.size = 8 * 1024 * 1024 * 1024
-    stream_gears.download(
-        url,
-        headers,
-        file_name,
-        segment
-    )
+    if file_name_callback:
+        stream_gears.download_with_callback(
+            url,
+            headers,
+            file_name,
+            segment,
+            file_name_callback
+        )
+    else:
+        stream_gears.download(
+            url,
+            headers,
+            file_name,
+            segment,
+        )
 
 
 def get_valid_filename(name):

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -298,6 +298,10 @@ class DownloadBase(ABC):
                     time.sleep(10)
                     continue
 
+                # 下载模式跳过下播延迟检测
+                if self.is_download:
+                    break
+
                 if delay and retry_count_delay < delay_all_retry_count:
                     retry_count_delay += 1
                     if delay < 60:

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -88,7 +88,7 @@ class DownloadBase(ABC):
         if self.downloader == 'streamlink' or self.downloader == 'ffmpeg':
             if shutil.which("ffmpeg"):
                 # streamlink无法处理flv,所以回退到ffmpeg
-                if self.downloader == 'streamlink' and '.flv' in parsed_url_path:
+                if self.downloader == 'streamlink' and '.flv' not in parsed_url_path:
                     return self.ffmpeg_download(use_streamlink=True)
                 else:
                     return self.ffmpeg_download()

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -34,7 +34,7 @@ class DownloadBase(ABC):
         self.url = url
         # 录制后保存文件格式而非源流格式 对应原配置文件format 仅ffmpeg及streamlink生效
         if not suffix:
-            logger.error(f'检测到suffix不存在，请补充后缀')
+            self.suffix = 'flv'
         else:
             self.suffix = suffix.lower()
         self.live_cover_path = None
@@ -109,9 +109,10 @@ class DownloadBase(ABC):
         return True
 
     def ffmpeg_segment_download(self):
+        # TODO 无日志
         # ffmpeg 输入参数
         input_args = [
-            '-loglevel', 'quiet', '-report', '-y'
+            '-loglevel', 'quiet', '-y'
         ]
         # ffmpeg 输出参数
         output_args = [

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -242,7 +242,7 @@ class DownloadBase(ABC):
             except:
                 logger.warning(f'执行后处理失败：{self.__class__.__name__} - {self.fname}', exc_info=True)
 
-    def __download_success_callback(self):
+    def download_success_callback(self):
         pass
 
     def run(self):
@@ -325,7 +325,7 @@ class DownloadBase(ABC):
                 logger.info(f'等待分段后处理完成: {self.__class__.__name__} - {self.fname} - {thread.name}')
                 thread.join()
         if (self.is_download and ret) or not self.is_download:
-            self.__download_success_callback()
+            self.download_success_callback()
         # self.segment_processor_thread
         logger.info(f'退出下载: {self.__class__.__name__} - {self.fname}')
         stream_info = {

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -166,9 +166,16 @@ class DownloadBase(ABC):
                     '-bsf:a', 'aac_adtstoasc',
                 ]
                 if use_streamlink:
-                    streamlink_cmd = ['streamlink', '--stream-segment-threads', '3', '--hls-playlist-reload-attempts',
-                                      '1',
-                                      self.raw_stream_url, 'best', '-O']
+                    streamlink_cmd = [
+                        'streamlink',
+                        '--stream-segment-threads', '3',
+                        '--hls-playlist-reload-attempts', '1',
+                        '--http-header',
+                        ';'.join([f'{key}={value}' for key, value in self.fake_headers.items()]),
+                        self.raw_stream_url,
+                        'best',
+                        '-O'
+                    ]
                     streamlink_proc = subprocess.Popen(streamlink_cmd, stdout=subprocess.PIPE)
                     input_uri = 'pipe:0'
                 else:

--- a/biliup/plugins/Danmaku/__init__.py
+++ b/biliup/plugins/Danmaku/__init__.py
@@ -143,7 +143,6 @@ class DanmakuClient:
                 logger.warning(f"{DanmakuClient.__name__}:{self.__url}: 弹幕写入异常 - {e}")
 
         try:
-            write_file(file_name)
             while True:
                 m = await self.__dm_queue.get()
                 if m.get('msg_type') == 'danmaku':

--- a/biliup/plugins/bilibili.py
+++ b/biliup/plugins/bilibili.py
@@ -9,6 +9,7 @@ from biliup.plugins.Danmaku import DanmakuClient
 from ..engine.decorators import Plugin
 from ..engine.download import DownloadBase
 
+
 @Plugin.download(regexp=r'(?:https?://)?(?:(?:www|m|live)\.)?bilibili\.com')
 class Bililive(DownloadBase):
     def __init__(self, fname, url, suffix='flv'):
@@ -73,21 +74,20 @@ class Bililive(DownloadBase):
 
             params = {
                 'room_id': room_id,
-                'protocol': '0,1',# 0: http_stream, 1: http_hls
-                'format': '0,1,2',# 0: flv, 1: ts, 2: fmp4
-                'codec': '0', # 0: avc, 1: hevc, 2: av1
+                'protocol': '0,1',  # 0: http_stream, 1: http_hls
+                'format': '0,1,2',  # 0: flv, 1: ts, 2: fmp4
+                'codec': '0',  # 0: avc, 1: hevc, 2: av1
                 'qn': qualityNumber,
-                'platform': 'html5', # web, html5, android, ios
+                'platform': 'html5',  # web, html5, android, ios
                 # 'ptype': '8',
                 'dolby': '5',
                 # 'panorama': '1' # 全景(不支持 html5)
             }
-            streamname_regexp = r"(live_\d+_\w+_\w+_?\w+?)" # 匹配 streamName
-
+            streamname_regexp = r"(live_\d+_\w+_\w+_?\w+?)"  # 匹配 streamName
 
             if self.raw_stream_url is not None \
-                and qualityNumber >= 10000 \
-                and not is_new_live:
+                    and qualityNumber >= 10000 \
+                    and not is_new_live:
                 # 同一个 streamName 即可复用，除非被超管切断
                 # 前面拿不到 streamName，目前使用开播时间判断
                 health, url = super().check_url_healthy(s, self.raw_stream_url)
@@ -104,8 +104,8 @@ class Bililive(DownloadBase):
                     logger.debug(f"{plugin_msg}: {main_api} 返回 {play_info}")
                     play_info = get_play_info(s, fallback_api, params)
                     if play_info is None or check_areablock(play_info['data']['playurl_info']['playurl']):
-                            logger.debug(f"{plugin_msg}: {fallback_api} 返回 {play_info}")
-                            return False
+                        logger.debug(f"{plugin_msg}: {fallback_api} 返回 {play_info}")
+                        return False
             except Exception:
                 logger.exception(f"{plugin_msg}")
                 return False
@@ -120,7 +120,7 @@ class Bililive(DownloadBase):
             if protocol == "hls_fmp4":
                 if len(stream['format']) > 1:
                     stream_format = stream['format'][1]
-                elif int(time.time()) - live_start_time <= 60: # 60s 宽容等待 fmp4
+                elif int(time.time()) - live_start_time <= 60:  # 60s 宽容等待 fmp4
                     return False
                 elif stream_format['format_name'] == 'ts':
                     stream_format = streams[0]['format'][0]
@@ -168,7 +168,9 @@ class Bililive(DownloadBase):
                     while i:
                         i -= 1
                         try:
-                            self.raw_stream_url = "{}{}{}".format(stream_info['url_info'][i]['host'], stream_url['base_url'], stream_info['url_info'][i]['extra'])
+                            self.raw_stream_url = "{}{}{}".format(stream_info['url_info'][i]['host'],
+                                                                  stream_url['base_url'],
+                                                                  stream_info['url_info'][i]['extra'])
                             url_health, _url = super().check_url_healthy(s, self.raw_stream_url)
                             if url_health:
                                 self.raw_stream_url = _url
@@ -192,21 +194,28 @@ class Bililive(DownloadBase):
 
     def danmaku_download_start(self, filename):
         if self.bilibili_danmaku:
-            self.danmaku = DanmakuClient(self.url, filename + "." + self.suffix)
+            self.danmaku = DanmakuClient(self.url, filename)
             self.danmaku.start()
+
+    def danmaku_segment(self, new_prev_file_name: str):
+        if self.danmaku:
+            self.danmaku.segment(new_prev_file_name)
 
     def close(self):
         if self.danmaku:
             self.danmaku.stop()
+            self.danmaku = None
+
 
 def get_play_info(s, api, params):
-    api = (lambda a: a if a.startswith(('http://', 'https://')) else 'http://' + a) (api)
+    api = (lambda a: a if a.startswith(('http://', 'https://')) else 'http://' + a)(api)
     full_url = f"{api}/xlive/web-room/v2/index/getRoomPlayInfo"
     try:
         return s.get(full_url, params=params, timeout=5).json()
     except Exception as e:
         logger.warning(f'{api} 获取直播流信息失败 {e}')
     return None
+
 
 # Copy from room-player.js
 def check_areablock(data):
@@ -219,6 +228,7 @@ def check_areablock(data):
         return True
     return False
 
+
 def do_login(s):
     try:
         return s.get('https://api.bilibili.com/x/web-interface/nav', timeout=5).json()
@@ -226,11 +236,13 @@ def do_login(s):
         logger.exception('Bililive do_login')
     return {}
 
+
 def oversea_expand(s, url, ov05_ip):
     # 强制替换ov05 302redirect之后的真实地址为指定的域名或ip达到自选ov05节点的目的
     r = s.get(url, stream=True)
     logger.debug(f'将ov-gotcha05的节点ip替换为了{ov05_ip}')
     return re.sub(r".*(?=/d1--ov-gotcha05)", f"http://{ov05_ip}", r.url, 1)
+
 
 def load_cookies(session, filename):
     if filename is not None:

--- a/biliup/plugins/douyin.py
+++ b/biliup/plugins/douyin.py
@@ -118,12 +118,17 @@ class Douyin(DownloadBase):
 
     def danmaku_download_start(self, filename):
         if self.douyin_danmaku:
-            self.danmaku = DanmakuClient(self.url, filename + "." + self.suffix)
+            self.danmaku = DanmakuClient(self.url, filename)
             self.danmaku.start()
+
+    def danmaku_segment(self, new_prev_file_name: str):
+        if self.danmaku:
+            self.danmaku.segment(new_prev_file_name)
 
     def close(self):
         if self.danmaku:
             self.danmaku.stop()
+            self.danmaku = None
 
 
 class DouyinUtils:

--- a/biliup/plugins/douyu.py
+++ b/biliup/plugins/douyu.py
@@ -92,12 +92,17 @@ class Douyu(DownloadBase):
 
     def danmaku_download_start(self, filename):
         if self.douyu_danmaku:
-            self.danmaku = DanmakuClient(self.url, filename + "." + self.suffix)
+            self.danmaku = DanmakuClient(self.url, filename)
             self.danmaku.start()
+
+    def danmaku_segment(self, new_prev_file_name: str):
+        if self.danmaku:
+            self.danmaku.segment(new_prev_file_name)
 
     def close(self):
         if self.danmaku:
             self.danmaku.stop()
+            self.danmaku = None
 
     def get_play_info(self, room_id, params):
         live_data = requests.post(f'https://www.douyu.com/lapi/live/getH5Play/{room_id}', headers=self.fake_headers,

--- a/biliup/plugins/general.py
+++ b/biliup/plugins/general.py
@@ -32,8 +32,9 @@ class YDownload(DownloadBase):
             logger.debug(info_list)
         return info_list
 
-    def download(self, filename):
+    def download(self):
         try:
+            filename = self.__gen_download_filename(is_fmt=True)
             self.ydl_opts = {'outtmpl': filename}
             with yt_dlp.YoutubeDL(self.ydl_opts) as ydl:
                 ydl.download([self.url])
@@ -62,8 +63,8 @@ class SDownload(DownloadBase):
         except streamlink.StreamlinkError:
             return
 
-    def download(self, filename):
-
+    def download(self):
+        filename = self.__gen_download_filename(is_fmt=True)
         # fd = stream.open()
         try:
             with self.stream.open() as fd:
@@ -75,7 +76,7 @@ class SDownload(DownloadBase):
                             return 1
                     return 0
         except OSError:
-            self.rename(filename)
+            self.__download_file_rename(filename + '.part', filename)
             raise
 
 
@@ -103,10 +104,10 @@ class Generic(DownloadBase):
             return False
         return True
 
-    def download(self, filename):
+    def download(self):
         if self.handler == self:
-            return super(Generic, self).download(filename)
-        return self.handler.download(filename)
+            return super(Generic, self).download()
+        return self.handler.download()
 
 
 __plugin__ = Generic

--- a/biliup/plugins/general.py
+++ b/biliup/plugins/general.py
@@ -34,7 +34,7 @@ class YDownload(DownloadBase):
 
     def download(self):
         try:
-            filename = self.__gen_download_filename(is_fmt=True)
+            filename = self.gen_download_filename(is_fmt=True)
             self.ydl_opts = {'outtmpl': filename}
             with yt_dlp.YoutubeDL(self.ydl_opts) as ydl:
                 ydl.download([self.url])
@@ -64,7 +64,7 @@ class SDownload(DownloadBase):
             return
 
     def download(self):
-        filename = self.__gen_download_filename(is_fmt=True)
+        filename = self.gen_download_filename(is_fmt=True)
         # fd = stream.open()
         try:
             with self.stream.open() as fd:
@@ -76,7 +76,7 @@ class SDownload(DownloadBase):
                             return 1
                     return 0
         except OSError:
-            self.__download_file_rename(filename + '.part', filename)
+            self.download_file_rename(filename + '.part', filename)
             raise
 
 

--- a/biliup/plugins/huya.py
+++ b/biliup/plugins/huya.py
@@ -100,12 +100,17 @@ class Huya(DownloadBase):
 
     def danmaku_download_start(self, filename):
         if self.huya_danmaku:
-            self.danmaku = DanmakuClient(self.url, filename + "." + self.suffix)
+            self.danmaku = DanmakuClient(self.url, filename)
             self.danmaku.start()
+
+    def danmaku_segment(self, new_prev_file_name: str):
+        if self.danmaku:
+            self.danmaku.segment(new_prev_file_name)
 
     def close(self):
         if self.danmaku:
             self.danmaku.stop()
+            self.danmaku = None
 
 
 def _get_info_in_html(room_id, fake_headers):

--- a/biliup/plugins/twitcasting.py
+++ b/biliup/plugins/twitcasting.py
@@ -56,15 +56,17 @@ class Twitcasting(DownloadBase):
 
     def danmaku_download_start(self, filename):
         if self.twitcasting_danmaku:
-            self.danmaku = DanmakuClient(self.url, filename + "." + self.suffix, {
-                'movie_id': self.movie_id,
-                'password': self.twitcasting_password,
-            })
+            self.danmaku = DanmakuClient(self.url, filename)
             self.danmaku.start()
+
+    def danmaku_segment(self, new_prev_file_name: str):
+        if self.danmaku:
+            self.danmaku.segment(new_prev_file_name)
 
     def close(self):
         if self.danmaku:
             self.danmaku.stop()
+            self.danmaku = None
 
 #
 # class TwitcastingUtils:

--- a/biliup/plugins/twitch.py
+++ b/biliup/plugins/twitch.py
@@ -8,7 +8,6 @@ from urllib.parse import urlencode
 
 import requests
 import yt_dlp
-from yt_dlp.utils import ExtractorError
 
 from . import logger
 from ..engine.decorators import Plugin

--- a/biliup/plugins/twitch.py
+++ b/biliup/plugins/twitch.py
@@ -21,7 +21,7 @@ VALID_URL_VIDEOS = r'https?://(?:(?:www|go|m)\.)?twitch\.tv/(?P<id>[^/]+)/(?:vid
 _CLIENT_ID = 'kimne78kx3ncx6brgo4mv6wki5h1ko'
 
 
-@Plugin.download(regexp=VALID_URL_BASE)
+@Plugin.download(regexp=VALID_URL_VIDEOS)
 class TwitchVideos(DownloadBase):
     def __init__(self, fname, url, suffix='flv'):
         DownloadBase.__init__(self, fname, url, suffix=suffix)
@@ -69,7 +69,7 @@ class TwitchVideos(DownloadBase):
 
 
 
-@Plugin.download(regexp=VALID_URL_VIDEOS)
+@Plugin.download(regexp=VALID_URL_BASE)
 class Twitch(DownloadBase):
     def __init__(self, fname, url, suffix='flv'):
         DownloadBase.__init__(self, fname, url, suffix=suffix)

--- a/biliup/plugins/twitch.py
+++ b/biliup/plugins/twitch.py
@@ -32,7 +32,7 @@ class TwitchVideos(DownloadBase):
             auth_token = TwitchUtils.get_auth_token()
             if auth_token:
                 cookie = io.StringIO(f"""# Netscape HTTP Cookie File
-.twitch.tv	TRUE	/	FALSE	0	auth-token	{auth_token}1
+.twitch.tv	TRUE	/	FALSE	0	auth-token	{auth_token}
 """)
             else:
                 cookie = None

--- a/biliup/plugins/twitch.py
+++ b/biliup/plugins/twitch.py
@@ -53,20 +53,17 @@ class TwitchVideos(DownloadBase):
                                 self.live_cover_url = thumbnails[len(thumbnails) - 1].get('url')
                             self.twitch_download_entry = entry
                         return True
-                except ExtractorError as e:
-                    if 'Unauthorized' in e.msg:
+                except Exception as e:
+                    if 'Unauthorized' in str(e):
                         TwitchUtils.invalid_auth_token()
                         continue
                     else:
                         logger.warning(f"{self.url}：获取错误", exc_info=True)
-                except:
-                    logger.warning(f"{self.url}：获取错误", exc_info=True)
                 return False
 
-    def __download_success_callback(self):
+    def download_success_callback(self):
         with yt_dlp.YoutubeDL({'download_archive': 'archive.txt'}) as ydl:
-                ydl.record_download_archive(self.twitch_download_entry)
-
+            ydl.record_download_archive(self.twitch_download_entry)
 
 
 @Plugin.download(regexp=VALID_URL_BASE)

--- a/biliup/plugins/youtube.py
+++ b/biliup/plugins/youtube.py
@@ -124,7 +124,8 @@ class Youtube(DownloadBase):
             else:
                 return False
 
-    def download(self, filename):
+    def download(self):
+        filename = self.__gen_download_filename(is_fmt=True)
         # ydl下载的文件在下载失败时不可控
         # 临时存储在其他地方
         download_dir = f'./cache/temp/youtube/{filename}'

--- a/biliup/plugins/youtube.py
+++ b/biliup/plugins/youtube.py
@@ -17,8 +17,8 @@ VALID_URL_BASE = r'https?://(?:(?:www|m)\.)?youtube\.com/(?P<id>.*?)\??(.*?)'
 
 @Plugin.download(regexp=VALID_URL_BASE)
 class Youtube(DownloadBase):
-    def __init__(self, fname, url):
-        super().__init__(fname, url)
+    def __init__(self, fname, url, suffix='flv'):
+        super().__init__(fname, url, suffix)
         self.ytb_danmaku = config.get('ytb_danmaku', False)
         self.youtube_cookie = config.get('user', {}).get('youtube_cookie')
         self.youtube_prefer_vcodec = config.get('youtube_prefer_vcodec')
@@ -125,7 +125,7 @@ class Youtube(DownloadBase):
                 return False
 
     def download(self):
-        filename = self.__gen_download_filename(is_fmt=True)
+        filename = self.gen_download_filename(is_fmt=True)
         # ydl下载的文件在下载失败时不可控
         # 临时存储在其他地方
         download_dir = f'./cache/temp/youtube/{filename}'

--- a/public/config.toml
+++ b/public/config.toml
@@ -6,7 +6,7 @@
 ### 2.ffmpeg（纯ffmpeg下载），请手动安装ffmpeg。
 ### 3.stream-gears
 #downloader = "ffmpeg"
-### 录像单文件大小限制，单位Byte，超过此大小分段下载
+### 录像单文件大小限制，单位Byte，超过此大小分段下载，下载回放时无法使用
 file_size = 2621440000
 ### 录像单文件时间限制，格式'00:00:00'（时分秒），超过此大小分段下载，如需使用大小分段请注释此字段
 #segment_time = "00:50:00"
@@ -52,7 +52,7 @@ check_sourcecode = 15
 ### 如遇到斗鱼录制卡顿可以尝试切换线路。
 ### tctc-h5（备用线路4）, tct-h5（备用线路5）, ali-h5（备用线路6）, hw-h5（备用线路7）, hs-h5（备用线路13）
 #douyucdn = "tct-h5"
-### 录制斗鱼弹幕，默认关闭【下载器为ffmpeg,streamlink时效果最优】
+### 录制斗鱼弹幕，默认关闭
 #douyu_danmaku = false
 ### 斗鱼自选画质
 ### 刚开播可能没有除了原画之外的画质 会先录制原画 后续视频分段(仅ffmpeg streamlink)时录制设置的画质
@@ -65,7 +65,7 @@ check_sourcecode = 15
 ### AL（阿里云 - 直播线路3）, TX（腾讯云 - 直播线路5）, HW（华为云 - 直播线路6）, WS（网宿）, HS（火山引擎 - 直播线路14）, AL13（阿里云）, HW16（华为云）, HY(星域云 - 直播线路66)
 #huya_cdn = "AL"
 #huya_cdn_fallback = false
-### 录制虎牙弹幕，默认关闭【下载器为ffmpeg,streamlink时效果最优】
+### 录制虎牙弹幕，默认关闭
 #huya_danmaku = false
 ### 虎牙自选录制码率
 ### 可以避免录制如20M的码率，每小时8G左右大小，上传及转码耗时过长。
@@ -74,7 +74,7 @@ check_sourcecode = 15
 #huya_max_ratio = 10000
 
 #------抖音------#
-### 录制抖音弹幕，默认关闭【下载器为ffmpeg,streamlink时效果最优】
+### 录制抖音弹幕，默认关闭
 #douyin_danmaku = false
 ### 抖音自选画质
 ### 刚开播可能没有除了原画之外的画质 会先录制原画 后续视频分段(仅ffmpeg streamlink)时录制设置的画质
@@ -166,15 +166,15 @@ check_sourcecode = 15
 #youtube_enable_download_playback = true
 
 #------Twitch直播录制------#
-### 录制Twitch弹幕，默认关闭【下载器为ffmpeg,streamlink时效果最优】
+### 录制Twitch弹幕，默认关闭
 #twitch_danmaku = false
-### 去除Twitch广告功能，默认开启【下载器为ffmpeg,streamlink时效果最优】
+### 去除Twitch广告功能，默认开启
 ### 这个功能会导致Twitch录播分段，因为遇到广告就自动断开了，这就是去广告。若需要录播完整一整段可以关闭这个，但是关了之后就会有紫色屏幕的CommercialTime
 ### 还有一个不想视频分段的办法是去花钱开一个Turbo会员，能不看广告，然后下面的user里把twitch的cookie填上，也能不看广告，自然就不会分段了
 #twitch_disable_ads = true
 
 #------TwitCasting------#
-### 录制Twitch弹幕，默认关闭【下载器为ffmpeg,streamlink时效果最优】
+### 录制Twitch弹幕，默认关闭
 #twitcasting_danmaku = false
 ### TwitCasting直播间密码 (可在录制主播设置中为主播单独配置)
 #twitcasting_password = ""

--- a/public/config.yaml
+++ b/public/config.yaml
@@ -6,7 +6,7 @@
 ### 2.ffmpeg（纯ffmpeg下载），请手动安装ffmpeg。
 ### 3.stream-gears
 #downloader: ffmpeg
-### 录像单文件大小限制，单位Byte，超过此大小分段下载
+### 录像单文件大小限制，单位Byte，超过此大小分段下载，下载回放时无法使用
 file_size: 2621440000
 ### 录像单文件时间限制，格式'00:00:00'（时分秒），超过此大小分段下载，如需使用大小分段请注释此字段
 #segment_time: '00:50:00'
@@ -51,7 +51,7 @@ check_sourcecode: 15
 ### 如遇到斗鱼录制卡顿可以尝试切换线路。可选以下线路
 ### tctc-h5（备用线路4）, tct-h5（备用线路5）, ali-h5（备用线路6）, hw-h5（备用线路7）, hs-h5（备用线路13）
 #douyucdn: tct-h5
-### 录制斗鱼弹幕，默认关闭【下载器为ffmpeg,streamlink时效果最优】
+### 录制斗鱼弹幕，默认关闭
 #douyu_danmaku: false
 ### 斗鱼自选画质
 ### 刚开播可能没有除了原画之外的画质 会先录制原画 后续视频分段(仅ffmpeg streamlink)时录制设置的画质
@@ -63,7 +63,7 @@ check_sourcecode: 15
 ### AL（阿里云 - 直播线路3）, TX（腾讯云 - 直播线路5）, HW（华为云 - 直播线路6）, WS（网宿）, HS（火山引擎 - 直播线路14）, AL13（阿里云）, HW16（华为云）, HY(星域云 - 直播线路66)
 #huya_cdn: AL
 #huya_cdn_fallback: false
-### 录制虎牙弹幕，默认关闭【下载器为ffmpeg,streamlink时效果最优】
+### 录制虎牙弹幕，默认关闭
 #huya_danmaku: false
 ### 虎牙自选录制码率
 ### 可以避免录制如20M的码率，每小时8G左右大小，上传及转码耗时过长。
@@ -72,7 +72,7 @@ check_sourcecode: 15
 #huya_max_ratio: 10000
 
 #------抖音------#
-### 录制抖音弹幕，默认关闭【下载器为ffmpeg,streamlink时效果最优】
+### 录制抖音弹幕，默认关闭
 #douyin_danmaku: false
 ### 抖音自选画质
 ### 刚开播可能没有除了原画之外的画质 会先录制原画 后续视频分段(仅ffmpeg streamlink)时录制设置的画质
@@ -164,15 +164,15 @@ check_sourcecode: 15
 #youtube_enable_download_playback: true
 
 #------Twitch直播录制------#
-### 录制Twitch弹幕，默认关闭【下载器为ffmpeg,streamlink时效果最优】
+### 录制Twitch弹幕，默认关闭
 #twitch_danmaku: false
-### 去除Twitch广告功能，默认开启【下载器为ffmpeg,streamlink时效果最优】
+### 去除Twitch广告功能，默认开启
 ### 这个功能会导致Twitch录播分段，因为遇到广告就自动断开了，这就是去广告。若需要录播完整一整段可以关闭这个，但是关了之后就会有紫色屏幕的CommercialTime
 ### 还有一个不想视频分段的办法是去花钱开一个Turbo会员，能不看广告，然后下面的user里把twitch的cookie填上，也能不看广告，自然就不会分段了
 #twitch_disable_ads: true
 
 #------TwitCasting------#
-### 录制Twitch弹幕，默认关闭【下载器为ffmpeg,streamlink时效果最优】
+### 录制Twitch弹幕，默认关闭
 #twitcasting_danmaku: false
 ### TwitCasting直播间密码 (可在录制主播设置中为主播单独配置)
 #twitcasting_password:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ urls = { Homepage = "https://github.com/ForgQi/bilibiliupload" }
 requires-python = ">= 3.8"
 dependencies = [
     "tomli-w>=1.0.0",
-    "stream-gears >= 0.1.22,<0.2",
+    "stream-gears >= 0.1.23,<0.2",
     "psutil >= 5.4.6",
     "aiofiles >= 22.1.0",
     "yt-dlp >= 2024.3.10",


### PR DESCRIPTION
- [x] 数据库记录正确的录制文件名
- [x] 保证弹幕文件名同步录制文件名
- [x] 修复下载(回放,视频)模式分段问题
- [x] 修复分段后处理不可用
- [x] 下载结束时等待分段后处理完成
- [x] 让ffmpeg or streamlink可以同时使用按时长及大小分段
- [x] 新增ffmpeg_segment分段下载模式
- [x] 调整下播延迟检测
- [x] 修复下载结束时间大于实际下播时间
- [x] 让Twitch下载视频时可用cookie
- [x] stream-gears新版
- [x] 使下载器正确的获取到bili_cookie_file的cookie
- [x] 使streamlink下载器使用预设header
- [x] 指定Youtube默认后戳
- [x] 检测到suffix不存在时默认为flv
- [x] 修复Twitch在cookie失效后webui更换不生效
- [x] 更新文档