### PR TITLE
精简 Docker 镜像

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ jobs:
             docker-compose --file docker-compose.test.yml build
             docker-compose --file docker-compose.test.yml run sut
           else
-            docker build . --file Dockerfile
+            docker build --build-arg repo_url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY . --file Dockerfile
           fi
 
   # Push image to GitHub Packages.

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,12 +84,9 @@ RUN set -eux; \
 		/var/cache/* \
 		/var/lib/apt/lists/* \
 		/var/tmp/* \
-		/var/log/*; \
-	\
-	printf '#!/bin/sh\nparams="$*"\nwhile true; do\nbiliup $params\nsleep 1\necho "Script restart"\ndone\n' > run_biliup.sh; \
-	chmod a+x run_biliup.sh
+		/var/log/*
 
 COPY --from=webui /biliup/biliup/web/public/ /biliup/biliup/web/public/
 WORKDIR /opt
 
-ENTRYPOINT ["/biliup/run_biliup.sh"]
+ENTRYPOINT ["biliup"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,11 @@ FROM node:lts as webui
 ARG repo_url
 ENV REPO_URL $repo_url
 
-RUN \
-  set -eux; \
-  git clone --depth 1 $REPO_URL; \
-  cd biliup; \
-  npm install; \
-  npm run build
+RUN set -eux; \
+	git clone --depth 1 $REPO_URL; \
+	cd biliup; \
+	npm install; \
+	npm run build
 
 # Deploy Biliup
 FROM python:3.12-slim as biliup
@@ -19,75 +18,78 @@ EXPOSE 19159/tcp
 VOLUME /opt
 
 RUN set -eux; \
-  \
-  savedAptMark="$(apt-mark showmanual)"; \
-  useApt=false; \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    wget \
-    xz-utils \
-  ; \
-  apt-mark auto '.*' > /dev/null; \
-  \
-  arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	useApt=false; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+			wget \
+			xz-utils \
+	; \
+	apt-mark auto '.*' > /dev/null; \
+	\
+	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	url='https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2023-10-31-14-21/'; \
-  case "$arch" in \
+	case "$arch" in \
 		'amd64') \
 			url="${url}ffmpeg-N-112565-g55f28eb627-linux64-gpl.tar.xz"; \
-			;; \
+		;; \
 		'arm64') \
 			url="${url}ffmpeg-N-112565-g55f28eb627-linuxarm64-gpl.tar.xz"; \
-			;; \
-		*) echo >&2 "error: unsupported architecture '$arch' (likely packaging update needed)"; \
-    useApt=true; \
-      ;; \
+		;; \
+		*) \
+			useApt=true; \
+		;; \
 	esac; \
 	\
 	if [ "$useApt" = true ] ; then \
-    apt-get install -y --no-install-recommends \
-      ffmpeg \
-    ; \
-  else \
-    wget -O ffmpeg.tar.xz "$url" --progress=dot:giga; \
-    tar -xJf ffmpeg.tar.xz -C /usr/local --strip-components=1; \
-    rm -rf \
-      /usr/local/doc \
-      /usr/local/man; \
-    rm -rf \
-      ffmpeg*; \
-  fi; \
-  # Clean up \
-  [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
-  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-  rm -rf \
-    /tmp/* \
-    /usr/share/doc/* \
-    /var/cache/* \
-    /var/lib/apt/lists/* \
-    /var/tmp/* \
-    /var/log/*;
+		apt-get install -y --no-install-recommends \
+				ffmpeg \
+		; \
+	else \
+		wget -O ffmpeg.tar.xz "$url" --progress=dot:giga; \
+		tar -xJf ffmpeg.tar.xz -C /usr/local --strip-components=1; \
+		rm -rf \
+			/usr/local/doc \
+			/usr/local/man; \
+		rm -rf \
+			ffmpeg*; \
+	fi; \
+	\
+	# Clean up \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf \
+		/tmp/* \
+		/usr/share/doc/* \
+		/var/cache/* \
+		/var/lib/apt/lists/* \
+		/var/tmp/* \
+		/var/log/*
 
 RUN set -eux; \
-  savedAptMark="$(apt-mark showmanual)"; \
-  apt-get update; \
-  apt-get install -y --no-install-recommends git g++; \
-  git clone --depth 1 $REPO_URL && \
-  cd biliup && \
-  pip3 install --no-cache-dir quickjs && \
-  pip3 install -e . && \
-  # Clean up \
-  apt-mark auto '.*' > /dev/null; \
-  [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
-  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-  rm -rf \
-    /tmp/* \
-    /usr/share/doc/* \
-    /var/cache/* \
-    /var/lib/apt/lists/* \
-    /var/tmp/* \
-    /var/log/*; \
-    printf '#!/bin/sh\nparams="$*"\nwhile true; do\nbiliup $params\nsleep 1\necho "Script restart"\ndone\n' > run_biliup.sh; \
-    chmod a+x run_biliup.sh
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends git g++; \
+	git clone --depth 1 $REPO_URL && \
+	cd biliup && \
+	pip3 install --no-cache-dir quickjs && \
+	pip3 install -e . && \
+	\
+	# Clean up \
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf \
+		/tmp/* \
+		/usr/share/doc/* \
+		/var/cache/* \
+		/var/lib/apt/lists/* \
+		/var/tmp/* \
+		/var/log/*; \
+	\
+	printf '#!/bin/sh\nparams="$*"\nwhile true; do\nbiliup $params\nsleep 1\necho "Script restart"\ndone\n' > run_biliup.sh; \
+	chmod a+x run_biliup.sh
 
 COPY --from=webui /biliup/biliup/web/public/ /biliup/biliup/web/public/
 WORKDIR /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build biliup's web-ui
 FROM node:lts as webui
-ARG repo_url
+ARG repo_url=https://github.com/ForgQi/biliup
 
 RUN set -eux; \
 	git clone --depth 1 $repo_url; \
@@ -10,7 +10,7 @@ RUN set -eux; \
 
 # Deploy Biliup
 FROM python:3.12-slim as biliup
-ARG repo_url
+ARG repo_url=https://github.com/ForgQi/biliup
 ENV TZ=Asia/Shanghai
 EXPOSE 19159/tcp
 VOLUME /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,10 @@ RUN set -eux; \
 			/usr/local/doc \
 			/usr/local/man; \
 		rm -rf \
+			/usr/local/bin/ffplay; \
+		rm -rf \
 			ffmpeg*; \
+		chmod a+x /usr/local/* ; \
 	fi; \
 	\
 	# Clean up \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 # Build biliup's web-ui
 FROM node:lts as webui
 ARG repo_url
-ENV REPO_URL $repo_url
 
 RUN set -eux; \
-	git clone --depth 1 $REPO_URL; \
+	git clone --depth 1 $repo_url; \
 	cd biliup; \
 	npm install; \
 	npm run build
@@ -12,7 +11,6 @@ RUN set -eux; \
 # Deploy Biliup
 FROM python:3.12-slim as biliup
 ARG repo_url
-ENV REPO_URL $repo_url
 ENV TZ=Asia/Shanghai
 EXPOSE 19159/tcp
 VOLUME /opt
@@ -71,7 +69,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends git g++; \
-	git clone --depth 1 $REPO_URL && \
+	git clone --depth 1 $repo_url && \
 	cd biliup && \
 	pip3 install --no-cache-dir quickjs && \
 	pip3 install -e . && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN set -eux; \
 	useApt=false; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-			wget \
-			xz-utils \
+		wget \
+		xz-utils \
 	; \
 	apt-mark auto '.*' > /dev/null; \
 	\
@@ -44,7 +44,7 @@ RUN set -eux; \
 	\
 	if [ "$useApt" = true ] ; then \
 		apt-get install -y --no-install-recommends \
-				ffmpeg \
+			ffmpeg \
 		; \
 	else \
 		wget -O ffmpeg.tar.xz "$url" --progress=dot:giga; \

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -407,31 +407,31 @@ class DownloadBase(ABC):
             except:
                 logger.exception(f'封面下载失败：{self.__class__.__name__} - {self.fname}')
 
-    @staticmethod
-    async def acheck_url_healthy(url):
-        timeout = 5
-        try:
-            if 'flv' in url:
-                timeout = 60
-            async with biliup.common.util.client.stream("GET", url, timeout=timeout) as r:
-                if 'm3u8' in url:
-                    import m3u8
-                    m3u8_obj = m3u8.loads(r.text)
-                    if m3u8_obj.is_variant:
-                        url = m3u8_obj.playlists[0].uri
-                        logger.info(f'stream url: {url}')
-                        async with biliup.common.util.client.stream("GET", url, timeout=timeout) as r:
-                            pass
-                elif r.headers.get('Location', False):
-                    url = r.headers['Location']
-                    logger.info(f'stream url: {url}')
-                    async with biliup.common.util.client.stream("GET", url, timeout=timeout) as r:
-                        pass
-                if r.status_code == 200:
-                    return True, url
-        except Exception as e:
-            logger.exception(f"{e} from {url}")
-        return False, None
+    # @staticmethod
+    # async def acheck_url_healthy(url):
+    #     timeout = 5
+    #     try:
+    #         if 'flv' in url:
+    #             timeout = 60
+    #         async with biliup.common.util.client.stream("GET", url, timeout=timeout) as r:
+    #             if 'm3u8' in url:
+    #                 import m3u8
+    #                 m3u8_obj = m3u8.loads(r.text)
+    #                 if m3u8_obj.is_variant:
+    #                     url = m3u8_obj.playlists[0].uri
+    #                     logger.info(f'stream url: {url}')
+    #                     async with biliup.common.util.client.stream("GET", url, timeout=timeout) as r:
+    #                         pass
+    #             elif r.headers.get('Location', False):
+    #                 url = r.headers['Location']
+    #                 logger.info(f'stream url: {url}')
+    #                 async with biliup.common.util.client.stream("GET", url, timeout=timeout) as r:
+    #                     pass
+    #             if r.status_code == 200:
+    #                 return True, url
+    #     except Exception as e:
+    #         logger.exception(f"{e} from {url}")
+    #     return False, None
 
     def gen_download_filename(self, is_fmt=False):
         if self.filename_prefix:  # 判断是否存在自定义录播命名设置

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -101,8 +101,8 @@ class DownloadBase(ABC):
             # 其他流stream_gears会按hls保存为ts
             self.suffix = 'ts'
         stream_gears_download(self.raw_stream_url, self.fake_headers, self.gen_download_filename(),
-                              config.get('segment_time'),
-                              config.get('file_size'),
+                              self.segment_time,
+                              self.file_size,
                               lambda file_name: self.__download_segment_callback(file_name))
         return True
 

--- a/biliup/plugins/bilibili.py
+++ b/biliup/plugins/bilibili.py
@@ -98,18 +98,18 @@ class Bililive(DownloadBase):
         }
         streamname_regexp = r"(live_\d+_\w+_\w+_?\w+?)"  # 匹配 streamName
 
-        if self.raw_stream_url is not None \
-                and qualityNumber >= 10000 \
-                and not is_new_live:
-            # 同一个 streamName 即可复用，除非被超管切断
-            # 前面拿不到 streamName，目前使用开播时间判断
-            health, url = await self.acheck_url_healthy(self.raw_stream_url)
-            if health:
-                logger.debug(f"{plugin_msg}: 复用 {url}")
-                return True
-            else:
-                logger.debug(f"{plugin_msg}: health-{health}; url-{self.raw_stream_url}")
-                self.raw_stream_url = None
+        # if self.raw_stream_url is not None \
+        #         and qualityNumber >= 10000 \
+        #         and not is_new_live:
+        #     # 同一个 streamName 即可复用，除非被超管切断
+        #     # 前面拿不到 streamName，目前使用开播时间判断
+        #     health, url = await self.acheck_url_healthy(self.raw_stream_url)
+        #     if health:
+        #         logger.debug(f"{plugin_msg}: 复用 {url}")
+        #         return True
+        #     else:
+        #         logger.debug(f"{plugin_msg}: health-{health}; url-{self.raw_stream_url}")
+        #         self.raw_stream_url = None
 
         try:
             play_info = await get_play_info(main_api, params)
@@ -159,12 +159,12 @@ class Bililive(DownloadBase):
             stream_url['extra'] = stream_info['url_info'][-1]['extra']
 
         # 移除 streamName 内画质标签
-        streamName = match1(stream_url['base_url'], streamname_regexp)
-        if streamName is not None and force_source and qualityNumber >= 10000:
-            new_base_url = stream_url['base_url'].replace(f"_{streamName.split('_')[-1]}", '')
-            if (await self.acheck_url_healthy(f"{stream_url['host']}{new_base_url}{stream_url['extra']}"))[0]:
-                stream_url['base_url'] = new_base_url
-                logger.debug(stream_url['base_url'])
+        # streamName = match1(stream_url['base_url'], streamname_regexp)
+        # if streamName is not None and force_source and qualityNumber >= 10000:
+        #     new_base_url = stream_url['base_url'].replace(f"_{streamName.split('_')[-1]}", '')
+        #     if (await self.acheck_url_healthy(f"{stream_url['host']}{new_base_url}{stream_url['extra']}"))[0]:
+        #         stream_url['base_url'] = new_base_url
+        #         logger.debug(stream_url['base_url'])
 
         self.raw_stream_url = f"{stream_url['host']}{stream_url['base_url']}{stream_url['extra']}"
 
@@ -174,34 +174,34 @@ class Bililive(DownloadBase):
         if ov05_ip and "ov-gotcha05" in stream_url['host']:
             self.raw_stream_url = await oversea_expand(self.raw_stream_url, ov05_ip)
 
-        url_health, _url = await self.acheck_url_healthy(self.raw_stream_url)
-        if not url_health:
-            if cdn_fallback:
-                i = len(stream_info['url_info'])
-                while i:
-                    i -= 1
-                    try:
-                        self.raw_stream_url = "{}{}{}".format(stream_info['url_info'][i]['host'],
-                                                              stream_url['base_url'],
-                                                              stream_info['url_info'][i]['extra'])
-                        url_health, _url = await self.acheck_url_healthy(self.raw_stream_url)
-                        if url_health:
-                            self.raw_stream_url = _url
-                            break
-                    except TimeoutError as e:
-                        logger.debug(f"Timeout Error: {e} at {stream_info['url_info'][i]['host']}")
-                        continue
-                    except Exception:
-                        logger.exception("Uncaught exception:")
-                        continue
-                    finally:
-                        logger.debug(f"{i} - {self.raw_stream_url}")
-                else:
-                    logger.debug(play_info)
-                    self.raw_stream_url = None
-                    return False
-        else:
-            self.raw_stream_url = _url
+        # url_health, _url = await self.acheck_url_healthy(self.raw_stream_url)
+        # if not url_health:
+        #     if cdn_fallback:
+        #         i = len(stream_info['url_info'])
+        #         while i:
+        #             i -= 1
+        #             try:
+        #                 self.raw_stream_url = "{}{}{}".format(stream_info['url_info'][i]['host'],
+        #                                                       stream_url['base_url'],
+        #                                                       stream_info['url_info'][i]['extra'])
+        #                 url_health, _url = await self.acheck_url_healthy(self.raw_stream_url)
+        #                 if url_health:
+        #                     self.raw_stream_url = _url
+        #                     break
+        #             except TimeoutError as e:
+        #                 logger.debug(f"Timeout Error: {e} at {stream_info['url_info'][i]['host']}")
+        #                 continue
+        #             except Exception:
+        #                 logger.exception("Uncaught exception:")
+        #                 continue
+        #             finally:
+        #                 logger.debug(f"{i} - {self.raw_stream_url}")
+        #         else:
+        #             logger.debug(play_info)
+        #             self.raw_stream_url = None
+        #             return False
+        # else:
+        #     self.raw_stream_url = _url
         print(self.raw_stream_url)
         return True
 

--- a/biliup/plugins/huya.py
+++ b/biliup/plugins/huya.py
@@ -70,26 +70,26 @@ class Huya(DownloadBase):
             return False
 
         # 虎牙直播流只允许连接一次，非常丑陋的代码
-        if cdn_fallback:
-            # with requests.Session() as s:
-            biliup.common.util.client.headers = self.fake_headers.copy()
-            url_health, _ = self.acheck_url_healthy(stream_url)
-            if not url_health:
-                logger.debug(f"{plugin_msg}: {list(sCdns.keys())}")
-                for sCdn in sCdns.keys():
-                    if sCdn == perf_cdn:
-                        continue
-                    logger.warning(f"{plugin_msg}: {perf_cdn} 无法连接，尝试 {sCdn}")
-                    stream_url, _ = await _build_stream_url(room_id, sCdn, self.fake_headers)
-                    url_health, _ = await self.acheck_url_healthy(stream_url)
-                    if url_health:
-                        perf_cdn = sCdn
-                        logger.warning(f"{plugin_msg}: CDN 切换为 {perf_cdn}")
-                        stream_url, _ = await _build_stream_url(room_id, perf_cdn, self.fake_headers)
-                        logger.debug(f"{plugin_msg}: {stream_url}")
-                        break
-                else:
-                    return False
+        # if cdn_fallback:
+        #     # with requests.Session() as s:
+        #     biliup.common.util.client.headers = self.fake_headers.copy()
+        #     url_health, _ = self.acheck_url_healthy(stream_url)
+        #     if not url_health:
+        #         logger.debug(f"{plugin_msg}: {list(sCdns.keys())}")
+        #         for sCdn in sCdns.keys():
+        #             if sCdn == perf_cdn:
+        #                 continue
+        #             logger.warning(f"{plugin_msg}: {perf_cdn} 无法连接，尝试 {sCdn}")
+        #             stream_url, _ = await _build_stream_url(room_id, sCdn, self.fake_headers)
+        #             url_health, _ = await self.acheck_url_healthy(stream_url)
+        #             if url_health:
+        #                 perf_cdn = sCdn
+        #                 logger.warning(f"{plugin_msg}: CDN 切换为 {perf_cdn}")
+        #                 stream_url, _ = await _build_stream_url(room_id, perf_cdn, self.fake_headers)
+        #                 logger.debug(f"{plugin_msg}: {stream_url}")
+        #                 break
+        #         else:
+        #             return False
 
         self.room_title = html_info['data'][0]['gameLiveInfo']['introduction']
         self.raw_stream_url = stream_url

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  biliup:
+    image: ghcr.io/biliup/caution:latest
+    container_name: biliup
+    restart: unless-stopped
+    ports:
+      - "<HOST_ADDRESS>:<HOST_PORT>:19159"
+    volumes:
+      - /path/to/save_folder:/opt
+    command: --password <your_password>


### PR DESCRIPTION
原镜像: `899.11`MB → 新镜像: `614.13`MB
~~biliup 主程序不再为 `PID 1` 需求来自@Kataick~~ 没有了，待讨论
ffmpeg 切换为 `yt-dlp` 编译版，以支持 中国大陆平台的 `FLV_HEVC`
stream-gears 现在会遵循 时间分段/大小分段 提供的默认值
暂时移除 bili_cdn_fallback、bili_force_source、huya_cdn_fallback、bili原画链接复用，逻辑待重写