### PR TITLE
Enhance docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Build biliup's web-ui
-FROM node:lts as webui
-ARG repo_url=https://github.com/ForgQi/biliup
+FROM node:20-bookworm as webui
 
 RUN set -eux; \
 	git clone --depth 1 $repo_url; \
@@ -9,7 +8,7 @@ RUN set -eux; \
 	npm run build
 
 # Deploy Biliup
-FROM python:3.12-slim as biliup
+FROM python:3.12-slim-bookworm as biliup
 ARG repo_url=https://github.com/ForgQi/biliup
 ENV TZ=Asia/Shanghai
 EXPOSE 19159/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ FROM python:3.12-slim as biliup
 ARG repo_url=https://github.com/ForgQi/biliup
 ENV TZ=Asia/Shanghai
 EXPOSE 19159/tcp
-VOLUME /opt
 
 RUN set -eux; \
 	\
@@ -90,6 +89,10 @@ RUN set -eux; \
 		/var/log/*
 
 COPY --from=webui /biliup/biliup/web/public/ /biliup/biliup/web/public/
-WORKDIR /opt
+RUN chmod 777 /biliup/docker-entrypoint.sh
 
-ENTRYPOINT ["biliup"]
+# If WORKDIR is modified, please modify the configuration in docker-entrypoint.sh simultaneously.
+WORKDIR /app
+
+ENTRYPOINT ["/biliup/docker-entrypoint.sh"]
+CMD ["biliup"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,7 @@ services:
     ports:
       - "<HOST_ADDRESS>:<HOST_PORT>:19159"
     volumes:
-      - /path/to/save_folder:/opt
-    command: --password <your_password>
+      - /path/to/save_folder:/app
+    environment:
+      # - PUID=0 # Uncomment if you want to change the default user 
+      # - PGID=0 # Uncomment if you want to change the default group

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+# Default to root, so old installations won't break
+export PUID=${PUID:-0}
+export PGID=${PGID:-0}
+
+# Check if the specified group with PGID exists, if not, create it.
+if ! getent group "$PGID" >/dev/null; then
+  groupadd -g "$PGID" appgroup
+fi
+# Create user if it doesn't exist.
+if ! getent passwd "$PUID" >/dev/null; then
+  useradd --create-home --shell /bin/sh --uid "$PUID" --gid "$PGID" appuser
+fi
+
+# Set privileges for /app but only if pid 1 user is root and we are dropping privileges.
+# If container is run as an unprivileged user, it means owner already handled ownership setup on their own.
+# Running chown in that case (as non-root) will cause error
+[ "$(id -u)" = "0" ] && [ "${PUID}" != "0" ] && chown -R ${PUID}:${PGID} /app && chown -R ${PUID}:${PGID} /biliup
+
+# Drop privileges (when asked to) if root, otherwise run as current user
+if [ "$(id -u)" = "0" ] && [ "${PUID}" != "0" ]; then
+  exec setpriv --reuid=$PUID --regid=$PGID --init-groups "$@"
+else
+  exec "$@"
+fi


### PR DESCRIPTION
1. Add docker-entrypoint.sh to support user set custom PUID/PGID like [Linuxserver](https://docs.linuxserver.io/general/understanding-puid-and-pgid/)'s images
2. Specify bookworm as Debian base image to ensure reuse

---
Remaining work:
- [ ] Command is not currently supported (like --password)
- [ ] Update Docs
- [ ] Need more test 