### PR TITLE
fix: val name err

### DIFF
--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -492,7 +492,7 @@ def get_valid_filename(name):
     '{self.fname}%Y-%m-%dT%H_%M_%S'
     """
     # s = str(name).strip().replace(" ", "_") #因为有些人会在主播名中间加入空格，为了避免和录播完毕自动改名冲突，所以注释掉
-    s = re.sub(r"(?u)[^-\w.%{}\[\]【】「」（）\s]", "", str(name))
+    s = re.sub(r"(?u)[^-\w.%{}\[\]【】「」（）・°\s]", "", str(name))
     if s in {"", ".", ".."}:
         raise RuntimeError("Could not derive file name from '%s'" % name)
     return s

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -203,7 +203,13 @@ class DownloadBase(ABC):
 
             output_args += self.opt_args
 
-            args = ['ffmpeg', '-y', *input_args, *output_args, '-c', 'copy', '-f', self.suffix,
+            if self.suffix.lower() == 'ts':
+                output_args += ['-f', 'mpegts']
+            elif self.suffix.lower() == 'mkv':
+                output_args += ['-f', 'matroska']
+            else:
+                output_args += ['-f', self.suffix]
+            args = ['ffmpeg', '-y', *input_args, *output_args, '-c', 'copy',
                     f'{fmt_file_name}.{self.suffix}.part']
             with subprocess.Popen(args, stdin=subprocess.DEVNULL if not streamlink_proc else streamlink_proc.stdout,
                                   stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as proc:

--- a/biliup/plugins/huya.py
+++ b/biliup/plugins/huya.py
@@ -73,17 +73,17 @@ class Huya(DownloadBase):
             logger.error(f"{self.plugin_msg}: 没有可用的链接")
             return False
 
-        cdnNameList = list(stream_urls.keys())
-        if perf_cdn not in cdnNameList:
-            logger.warning(f"{self.plugin_msg}: {perf_cdn} CDN不存在，自动切换到 {cdnNameList[0]}")
-            perf_cdn = cdnNameList[0]
+        cdn_name_list = list(stream_urls.keys())
+        if perf_cdn not in cdn_name_list:
+            logger.warning(f"{self.plugin_msg}: {perf_cdn} CDN不存在，自动切换到 {cdn_name_list[0]}")
+            perf_cdn = cdn_name_list[0]
 
         # 虎牙直播流只允许连接一次
         if cdn_fallback:
             _url = await self.acheck_url_healthy(stream_urls[perf_cdn])
             if _url is None:
-                logger.info(f"{self.plugin_msg}: 提供如下CDN {cdnNameList}")
-                for cdn in cdnNameList:
+                logger.info(f"{self.plugin_msg}: 提供如下CDN {cdn_name_list}")
+                for cdn in cdn_name_list:
                     if cdn == perf_cdn:
                         continue
                     logger.info(f"{self.plugin_msg}: cdn_fallback 尝试 {cdn}")
@@ -145,10 +145,10 @@ class Huya(DownloadBase):
             logger.error(f"{self.plugin_msg}: build_stream_url {stream_name} {anti_code}")
             return {}
         # HY 和 HYZJ 均为 P2P
-        sStreams = {item['sCdnType']: \
+        streams = {item['sCdnType']: \
                     f"{item[f's{protocol}Url']}/{stream_name}.{suffix}?{anti_code}" \
                     for item in stream_info if 'HY' not in item['sCdnType']}
-        return sStreams
+        return streams
 
 
 def build_query(sStreamName, sAntiCode) -> str:

--- a/biliup/plugins/huya.py
+++ b/biliup/plugins/huya.py
@@ -191,4 +191,4 @@ def build_query(sStreamName, sAntiCode) -> str:
         "sdk_sid": str(int(time.time() * 1000)),
         "codec": "264",
     }
-    return '&'.join([f"{k}={v}" for k, v in anticode.items()])
+    return '&'.join([f"{k}={v}" for k, v in anti_code.items()])


### PR DESCRIPTION
 - huya 变量名错误
 - ffmpeg 正确匹配文件格式的 output format 以支持 mkv 和 ts 
 - 文件名允许`・`（なかぐろ）和`°`
 > 示例主播: https://space.bilibili.com/3546694188796294 https://space.bilibili.com/197098