### PR TITLE
feat: danmaku xml 兼容b站格式

### DIFF
--- a/biliup/Danmaku/__init__.py
+++ b/biliup/Danmaku/__init__.py
@@ -147,7 +147,7 @@ class DanmakuClient(IDanmakuClient):
                 logger.warning(f"{DanmakuClient.__name__}:{self.__url}: 弹幕写入异常", exc_info=True)
 
         while True:
-            root = etree.Element("root")
+            root = etree.Element("i")
             etree.indent(root, "\t")
             tree = etree.ElementTree(root, parser=etree.XMLParser(recover=True))
             start_time = time.time()


### PR DESCRIPTION
弹幕文件的xml适配B站格式，本地可以直接用[弹弹play](https://www.dandanplay.com/)直接播放弹幕版视频。