### PR TITLE
修复v0.4.75抖音默认开启录制弹幕的问题

### DIFF
--- a/biliup/plugins/douyin.py
+++ b/biliup/plugins/douyin.py
@@ -152,7 +152,7 @@ class Douyin(DownloadBase):
         return True
 
     def danmaku_init(self):
-        if self.douyin_danmaku or True:
+        if self.douyin_danmaku:
             content = {
                 'web_rid': self.__web_rid,
                 'sec_uid': self.__sec_uid,


### PR DESCRIPTION
修复由[支持抖音短链录制弹幕](https://github.com/biliup/biliup/commit/56eb8d937b0e1b8a7305442280f9d4b3b3a2a228)造成的[错误](https://github.com/biliup/biliup/issues/1019#issuecomment-2272758013)