### PR TITLE
feat: enhance dashboard and plugin

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -213,7 +213,7 @@ const Dashboard: React.FC = () => {
                                                 {/* CC直播 */}
                                                 <CC />
                                                 {/* 抖音 */}
-                                                <Douyin />
+                                                <Douyin entity={entity} />
                                                 {/* 斗鱼 */}
                                                 <Douyu />
                                                 {/* 虎牙 */}

--- a/app/ui/plugins/bilibili.tsx
+++ b/app/ui/plugins/bilibili.tsx
@@ -86,7 +86,7 @@ const Bilibili: React.FC<Props> = (props) => {
                         padding: 0,
                     }}
                     optionList={list}
-                    extraText="只支持「biliup-rs」生成的文件。当与上一个配置项同时存在时，将优先使用文件。"
+                    extraText="只支持「biliup-rs」生成的文件。与 Cookie 文本 同时存在时，优先使用文件。"
                     showClear={true}
                 />
                 <Form.Select
@@ -95,10 +95,9 @@ const Bilibili: React.FC<Props> = (props) => {
                         <div style={{ fontSize: "14px" }}>
                             哔哩哔哩直播流协议。
                             <br />
-                            由于B站转码为 fmp4 需要一定时间，或者某些小主播（大部分只有原画选项的主播）无fmp4流时，
-                            如果开播时间小于60s，将会反复尝试获取 fmp4 流，如果没获取到就回退到 flv 流。
+                            该设置项遵循 hls_fmp4 转码等待时间（bili_hls_transcode_timeout）。
                             <br />
-                            由于 ffmpeg 不支持多并发，且 stream-gears 尚未支持 fmp4，推荐切换为 streamlink 来录制 hls 流。
+                            stream-gears 尚未支持 hls_fmp4，请切换为 ffmpeg 或 streamlink 来录制。
                         </div>
                     }
                     label="直播流协议（bili_protocol）"
@@ -117,26 +116,6 @@ const Bilibili: React.FC<Props> = (props) => {
                     <Select.Option value="hls_fmp4">hls_fmp4</Select.Option>
                 </Form.Select>
                 <Form.Input
-                    field="bili_perfCDN"
-                    extraText="哔哩哔哩直播优选CDN，默认无。"
-                    label="优选CDN（bili_perfCDN）"
-                    placeholder="cn-gotcha208, ov-gotcha05"
-                    style={{ width: "100%" }}
-                    fieldStyle={{
-                        alignSelf: "stretch",
-                        padding: 0,
-                    }}
-                />
-                <Form.Switch
-                    field="bili_cdn_fallback"
-                    extraText="CDN 回退（Fallback），默认为关闭。例如海外机器优选 ov05 之后，如果 ov05 流一直无法下载，将会自动回退到 ov07 进行下载。仅限相同流协议。"
-                    label="CDN 回退（bili_cdn_fallback）"
-                    fieldStyle={{
-                        alignSelf: "stretch",
-                        padding: 0,
-                    }}
-                />
-                <Form.Input
                     field="bili_liveapi"
                     extraText="自定义哔哩哔哩直播主要 API，用于获取指定区域（大陆或海外）的直播流链接，默认使用官方 API。"
                     label="哔哩哔哩直播主要API（bili_liveapi）"
@@ -146,6 +125,13 @@ const Bilibili: React.FC<Props> = (props) => {
                         alignSelf: "stretch",
                         padding: 0,
                     }}
+                    showClear={true}
+                    rules={[
+                        {
+                            pattern: /^https?:\/\/(?:[\w-]+(?::[\w-]+)?@)?([\w-]+\.)+[\w-]+(?::\d+)?(?:\/[\w-/.]*)?$/,
+                            message: '请输入有效的API地址，必须以 http:// 或 https:// 开头'
+                        }
+                    ]}
                 />
                 <Form.Input
                     field="bili_fallback_api"
@@ -157,7 +143,6 @@ const Bilibili: React.FC<Props> = (props) => {
                             API，并将哔哩哔哩直播回退API（bili_fallback_api）设置为官方
                             API，然后优选「fmp4」流并使用「streamlink」下载插件（downloader），
                             最后设置优选「cn-gotcha204,ov-gotcha05」两个节点。
-                            <br />
                             这样大主播可以使用 cn204 的 fmp4 流稳定录制。
                         </div>
                     }
@@ -168,10 +153,70 @@ const Bilibili: React.FC<Props> = (props) => {
                         alignSelf: "stretch",
                         padding: 0,
                     }}
+                    showClear={true}
+                    rules={[
+                        {
+                            pattern: /^https?:\/\/(?:[\w-]+(?::[\w-]+)?@)?([\w-]+\.)+[\w-]+(?::\d+)?(?:\/[\w-/.]*)?$/,
+                            message: '请输入有效的API地址，必须以 http:// 或 https:// 开头'
+                        }
+                    ]}
+                />
+                <Form.TagInput
+                    field="bili_cdn"
+                    extraText="哔哩哔哩直播CDN，默认无。"
+                    label="直播CDN（bili_cdn）"
+                    placeholder="例: cn-gotcha204,ov-gotcha05。用英文逗号分隔以批量输入，失焦/Enter保存"
+                    style={{ width: "100%" }}
+                    fieldStyle={{
+                        alignSelf: "stretch",
+                        padding: 0,
+                    }}
+                    showClear={true}
+                    rules={[
+                        {
+                            validator: (rule, value) => {
+                                return Array.isArray(value) && value.every(item => /^(cn|ov)-gotcha\d+$/.test(item));
+                            },
+                            message: '例: cn-gotcha204, ov-gotcha05'
+                        }
+                    ]}
+                />
+                <Form.Switch
+                    field="bili_cdn_fallback"
+                    extraText="CDN 回退（Fallback），默认为关闭。例如海外机器优选 ov05 之后，如果 ov05 流一直无法下载，将会自动回退到 ov07 进行下载。仅限相同流协议。"
+                    label="CDN 回退（bili_cdn_fallback）"
+                    fieldStyle={{
+                        alignSelf: "stretch",
+                        padding: 0,
+                    }}
+                />
+                <Form.Switch
+                    field="bili_anonymous_origin"
+                    extraText="使用自定义API获取 master.m3u8 内的 hls_fmp4 原画流，无法录制特殊直播。默认关闭。"
+                    label="免登录原画（bili_anonymous_origin）"
+                    fieldStyle={{
+                        alignSelf: "stretch",
+                        padding: 0,
+                    }}
+                />
+                <Form.Switch
+                    field="bili_ov2cn"
+                    extraText={
+                        <div style={{ fontSize: "14px" }}>
+                            将海外cdn域名替换为大陆cdn域名，默认关闭。
+                            <br />
+                            例：将海外的 ov-gotcha07 替换为 cn-gotcha07，直播 cdn 处仍然填写 ov-gotcha07。
+                        </div>
+                    }
+                    label="海外转大陆（bili_ov2cn）"
+                    fieldStyle={{
+                        alignSelf: "stretch",
+                        padding: 0,
+                    }}
                 />
                 <Form.Switch
                     field="bili_force_source"
-                    extraText="哔哩哔哩强制真原画（仅限非 FLV 流，且画质等级 bili_qn >= 10000），默认为关闭，不保证可用性。"
+                    extraText="哔哩哔哩强制真原画（仅限 hls_fmp4 流，且画质等级 bili_qn >= 10000），默认为关闭，不保证可用性。"
                     label="强制获取真原画（bili_force_source）"
                     fieldStyle={{
                         alignSelf: "stretch",
@@ -187,12 +232,23 @@ const Bilibili: React.FC<Props> = (props) => {
                         padding: 0,
                     }}
                 />
+                <Form.InputNumber
+                    field="bili_hls_transcode_timeout"
+                    extraText="hls_fmp4 转码等待时间，超时后回退到 flv 流。默认 60 秒。"
+                    label="hls_fmp4 转码等待时间（bili_hls_transcode_timeout）"
+                    style={{ width: "100%" }}
+                    placeholder="60"
+                    fieldStyle={{
+                        alignSelf: "stretch",
+                        padding: 0,
+                    }}
+                />
                 <Form.TagInput
                     allowDuplicates={false}
                     addOnBlur={true}
                     separator=','
                     field="bili_replace_cn01"
-                    extraText="该功能在 bili_force_source 后生效"
+                    extraText="该功能在 强制真原画 之前生效"
                     label="替换 CN01 sid (bili_replace_cn01)"
                     style={{ width: "100%" }}
                     fieldStyle={{
@@ -201,12 +257,12 @@ const Bilibili: React.FC<Props> = (props) => {
                     }}
                     showClear={true}
                     placeholder="可用英文逗号分隔以批量输入 sid，失焦/Enter 保存"
-                    onChange={v => console.log(v)}
+                    // onChange={v => console.log(v)}
                     rules={[
                         {
                             validator: (rule, value) => {
                                 value = value ?? (console.log(value), []);
-                                return Array.isArray(value) && value.every(item => /^cn-[a-z]{2,6}-[a-z]{2}(-[0-9]{2}){2}$/.test(item));
+                                return Array.isArray(value) && value.every(item => /^cn-[a-z]{2,6}-[a-z]{2,4}(-[0-9]{2}){2}$/.test(item));
                             },
                             message: '例: cn-hjlheb-cu-01-01,cn-tj-ct-01-01'
                         }

--- a/app/ui/plugins/bilibili.tsx
+++ b/app/ui/plugins/bilibili.tsx
@@ -22,7 +22,7 @@ const Bilibili: React.FC<Props> = (props) => {
                             刚开播如果无选择的画质，会先录制原画，
                             后续视频分段时，如果下载插件为非 stream-gears，会切换到选择的画质。
                             <br />
-                            如果选择的画质不提供，会选择更低一档的画质。
+                            如果选择的画质没有提供，会使用次档画质中最接近的画质，免登录原画会使用最高画质。
                         </div>
                     }
                     label="画质等级（bili_qn）"
@@ -112,7 +112,7 @@ const Bilibili: React.FC<Props> = (props) => {
                     <Select.Option value="stream">
                         stream（flv，默认）
                     </Select.Option>
-                    <Select.Option value="hls_ts">hls_ts</Select.Option>
+                    {/* <Select.Option value="hls_ts">hls_ts</Select.Option> */}
                     <Select.Option value="hls_fmp4">hls_fmp4</Select.Option>
                 </Form.Select>
                 <Form.Input
@@ -216,7 +216,7 @@ const Bilibili: React.FC<Props> = (props) => {
                 />
                 <Form.Switch
                     field="bili_force_source"
-                    extraText="哔哩哔哩强制真原画（仅限 hls_fmp4 流，且画质等级 bili_qn >= 10000），默认为关闭，不保证可用性。"
+                    extraText="移除streamName的二压小尾巴（仅限 hls_fmp4 流，且画质等级 bili_qn >= 10000），默认为关闭，不保证可用性。"
                     label="强制获取真原画（bili_force_source）"
                     fieldStyle={{
                         alignSelf: "stretch",
@@ -242,13 +242,14 @@ const Bilibili: React.FC<Props> = (props) => {
                         alignSelf: "stretch",
                         padding: 0,
                     }}
+                    showClear={true}
                 />
                 <Form.TagInput
                     allowDuplicates={false}
                     addOnBlur={true}
                     separator=','
                     field="bili_replace_cn01"
-                    extraText="该功能在 强制真原画 之前生效"
+                    extraText="该功能在 强制获取真原画 之前生效"
                     label="替换 CN01 sid (bili_replace_cn01)"
                     style={{ width: "100%" }}
                     fieldStyle={{

--- a/app/ui/plugins/douyin.tsx
+++ b/app/ui/plugins/douyin.tsx
@@ -100,11 +100,6 @@ const Douyin: React.FC<Props> = (props) => {
                         alignSelf: "stretch",
                         padding: 0,
                     }}
-                    initValue={
-                        entity?.hasOwnProperty("douyin_double_screen")
-                            ? entity["douyin_double_screen"]
-                            : true
-                    }
                 />
             </Collapse.Panel>
         </>

--- a/app/ui/plugins/douyin.tsx
+++ b/app/ui/plugins/douyin.tsx
@@ -2,7 +2,12 @@
 import React from "react";
 import { Form, Select, Collapse } from "@douyinfe/semi-ui";
 
-const Douyin: React.FC = () => {
+type Props = {
+    entity: any;
+};
+
+const Douyin: React.FC<Props> = (props) => {
+    const entity = props.entity;
     return (
         <>
             <Collapse.Panel header="抖音" itemKey="douyin">
@@ -65,6 +70,7 @@ const Douyin: React.FC = () => {
                         alignSelf: "stretch",
                         padding: 0,
                     }}
+                    showClear={true}
                 />
                 <Form.Select
                     field="douyin_protocol"
@@ -80,6 +86,26 @@ const Douyin: React.FC = () => {
                     <Select.Option value="flv">flv（默认）</Select.Option>
                     <Select.Option value="hls">hls</Select.Option>
                 </Form.Select>
+                <Form.Switch
+                    field="douyin_double_screen"
+                    extraText={
+                        <div style={{ fontSize: "14px" }}>
+                            是否录制抖音双屏直播的原像素拼接流，默认关闭。
+                            <br />
+                            关闭时录制 横像素不变的 缩放拼接流，可能存在画质损失；开启时录制 纵像素不变的 raw 双屏拼接流。
+                        </div>
+                    }
+                    label="双屏直播录制方式（douyin_double_screen）"
+                    fieldStyle={{
+                        alignSelf: "stretch",
+                        padding: 0,
+                    }}
+                    initValue={
+                        entity?.hasOwnProperty("douyin_double_screen")
+                            ? entity["douyin_double_screen"]
+                            : true
+                    }
+                />
             </Collapse.Panel>
         </>
     );

--- a/app/ui/plugins/douyin.tsx
+++ b/app/ui/plugins/douyin.tsx
@@ -39,13 +39,7 @@ const Douyin: React.FC<Props> = (props) => {
                 </Form.Select>
                 <Form.Switch
                     field="douyin_danmaku"
-                    extraText={
-                        <div style={{ fontSize: "14px" }}>
-                            录制抖音弹幕，默认关闭。
-                            <br />
-                            暂不支持视频按时长分段下的弹幕文件自动分段；仅在使用ffmpeg（包括streamlink混合模式）时得到支持。
-                        </div>
-                    }
+                    extraText="录制抖音弹幕，默认关闭。"
                     label="录制弹幕（douyin_danmaku）"
                     fieldStyle={{
                         alignSelf: "stretch",

--- a/app/ui/plugins/global.tsx
+++ b/app/ui/plugins/global.tsx
@@ -35,9 +35,9 @@ const Global: React.FC = () => {
                             选择全局默认的下载插件, 可选:
                             <br />
                             1.
-                            streamlink（streamlink 用于多线程下载 hls 流，对于 FLV 流将仅使用 ffmpeg。请手动安装ffmpeg）
+                            streamlink（仅限 hls 流，不支持的流将回退到 ffmpeg。请手动安装ffmpeg）
                             <br />
-                            2. ffmpeg（纯ffmpeg下载。请手动安装ffmpeg）
+                            2. ffmpeg（ffmpeg 下载。请手动安装ffmpeg）
                             <br />
                             3. stream-gears（默认）
                         </div>
@@ -61,7 +61,7 @@ const Global: React.FC = () => {
                     label="视频分段大小（file_size）"
                     extraText={
                         <div style={{ fontSize: "14px" }}>
-                            录像单文件大小限制，超过此大小分段下载，下载回放时无法使用
+                            录像单文件大小限制，超过此大小触发文件分割。下载回放时无法使用。
                             <br />
                             单位：Byte，示例：4294967296（4GB）
                         </div>
@@ -79,7 +79,7 @@ const Global: React.FC = () => {
                     field="segment_time"
                     extraText={
                         <div style={{ fontSize: "14px" }}>
-                            录像单文件时间限制，超过此时长分段下载。
+                            录像单文件时间限制，超过此时长触发文件分割。
                             <br />
                             格式：&apos;00:00:00&apos;（时:分:秒）
                         </div>
@@ -91,6 +91,22 @@ const Global: React.FC = () => {
                         alignSelf: "stretch",
                         padding: 0,
                     }}
+                    showClear={true}
+                    rules={[
+                        {
+                            pattern: /^[^：]*$/,
+                            message: "请使用英文冒号"
+                        },
+                        {
+                            pattern: /^[0-9:]*$/,
+                            message: "只接受数字和英文冒号"
+                        },
+                        {
+                            pattern: /^[0-9]{2,4}:[0-5][0-9]:[0-5][0-9]$/,
+                            message: "分或秒不符合规范"
+                        }
+                    ]}
+                    stopValidateWithError={true}
                 />
                 <Form.Input
                     field="filename_prefix"
@@ -98,7 +114,7 @@ const Global: React.FC = () => {
                         <div style={{ fontSize: "14px" }}>
                             全局文件名模板。可被单个主播文件名模板覆盖。可用变量如下
                             <br />
-                            {'\u007B'}streamer{'\u007D'}: 录播备注
+                            {'\u007B'}streamer{'\u007D'}: 录播备注（必须保留）
                             <span style={{ margin: "0 20px"}}></span>
                             {'\u007B'}title{'\u007D'}: 直播标题
                             <br />
@@ -112,6 +128,7 @@ const Global: React.FC = () => {
                         alignSelf: "stretch",
                         padding: 0,
                     }}
+                    showClear={true}
                 />
                 <Form.Switch
                     field="segment_processor_parallel"
@@ -142,6 +159,7 @@ const Global: React.FC = () => {
                         alignSelf: "stretch",
                         padding: 0,
                     }}
+                    showClear={true}
                 />
 
                 <Form.InputNumber
@@ -163,6 +181,7 @@ const Global: React.FC = () => {
                         alignSelf: "stretch",
                         padding: 0,
                     }}
+                    showClear={true}
                 />
                 <Form.InputNumber
                     field="event_loop_interval"
@@ -180,6 +199,7 @@ const Global: React.FC = () => {
                         alignSelf: "stretch",
                         padding: 0,
                     }}
+                    showClear={true}
                 />
                 <Form.InputNumber
                     field="pool1_size"
@@ -191,6 +211,7 @@ const Global: React.FC = () => {
                         alignSelf: "stretch",
                         padding: 0,
                     }}
+                    showClear={true}
                 />
             </div>
 
@@ -269,13 +290,13 @@ const Global: React.FC = () => {
                     showClear={true}
                 >
                     <Form.Select.Option value="AUTO">AUTO（自动，默认）</Form.Select.Option>
-                    <Form.Select.Option value="bda">bda</Form.Select.Option>
-                    <Form.Select.Option value="bda2">bda2</Form.Select.Option>
-                    <Form.Select.Option value="ws">ws</Form.Select.Option>
-                    <Form.Select.Option value="qn">qn</Form.Select.Option>
-                    <Form.Select.Option value="bldsa">bldsa</Form.Select.Option>
-                    <Form.Select.Option value="tx">tx</Form.Select.Option>
-                    <Form.Select.Option value="txa">txa</Form.Select.Option>
+                    <Form.Select.Option value="alia">alia（海外-阿里云）</Form.Select.Option>
+                    {/* <Form.Select.Option value="bda">bda</Form.Select.Option> */}
+                    <Form.Select.Option value="bda2">bda2（大陆-百度云）</Form.Select.Option>
+                    <Form.Select.Option value="bldsa">bldsa（大陆-B站自建）</Form.Select.Option>
+                    <Form.Select.Option value="qn">qn（全球-七牛）</Form.Select.Option>
+                    <Form.Select.Option value="tx">tx（大陆-腾讯云）</Form.Select.Option>
+                    <Form.Select.Option value="txa">txa（海外-腾讯云）</Form.Select.Option>
                 </Form.Select>
                 <Form.InputNumber
                     field="threads"
@@ -287,6 +308,7 @@ const Global: React.FC = () => {
                         alignSelf: "stretch",
                         padding: 0,
                     }}
+                    showClear={true}
                 />
 
                 <Form.InputNumber

--- a/app/ui/plugins/huya.tsx
+++ b/app/ui/plugins/huya.tsx
@@ -110,7 +110,7 @@ const Huya: React.FC<Props> = (props) => {
                 />
                 <Form.Switch
                     field="huya_mobile_api"
-                    extraText="使用移动端API可以绕过部分游客观看原画的时长限制"
+                    extraText="使用移动端API可以绕过 PCWEB 端对原画的时长限制"
                     label="虎牙使用移动端API（huya_mobile_api）"
                     fieldStyle={{
                         alignSelf: "stretch",

--- a/app/ui/plugins/huya.tsx
+++ b/app/ui/plugins/huya.tsx
@@ -96,7 +96,7 @@ const Huya: React.FC<Props> = (props) => {
                 </Form.Select>
                 <Form.Switch
                     field="huya_imgplus"
-                    extraText="是否录制二次编码的直播流。默认为启用，关闭后可能无法下载。部分直播间的分辨率超分和HDR画质依赖于二次编码，请谨慎关闭。"
+                    extraText="是否录制二次编码的直播流。默认为启用，关闭后可能无法下载。部分直播间的分辨率超分（如2k/4k）和HDR画质依赖于二次编码，请谨慎关闭。"
                     label="虎牙二次编码（huya_imgplus）"
                     initValue={
                         entity?.hasOwnProperty("huya_imgplus")

--- a/biliup/Danmaku/bilibili.py
+++ b/biliup/Danmaku/bilibili.py
@@ -26,13 +26,15 @@ class Bilibili:
     }
 
     @staticmethod
-    async def get_ws_info(url, context):
+    async def get_ws_info(url, content):
         danmu_wss_url = 'wss://broadcastlv.chat.bilibili.com/sub'
+        room_id = content.get('room_id')
         async with aiohttp.ClientSession(headers=Bilibili.headers) as session:
-            async with session.get("https://api.live.bilibili.com/room/v1/Room/room_init?id=" + match1(url, r'/(\d+)'),
+            if not room_id:
+                async with session.get("https://api.live.bilibili.com/room/v1/Room/room_init?id=" + match1(url, r'/(\d+)'),
                                    timeout=5) as resp:
-                room_json = await resp.json()
-                room_id = room_json['data']['room_id']
+                    room_json = await resp.json()
+                    room_id = room_json['data']['room_id']
             async with session.get(f"https://api.live.bilibili.com/xlive/web-room/v1/index/getDanmuInfo?id={room_id}",
                                    timeout=5) as resp:
                 danmu_info = await resp.json()

--- a/biliup/app.py
+++ b/biliup/app.py
@@ -60,7 +60,7 @@ async def shot(event):
             await singleton_check(event, context['PluginInfo'].inverted_index[cur], cur)
             index += 1
             skip = context['PluginInfo'].url_status[cur] == 1 and index < len(event.url_list)
-            if skip:  # 在一次 url_list 内，如果 url 正在下载，则跳过本次等待以加快下一个检测
+            if skip:  # 全部主播检测后不应跳过
                 continue
         except Exception:
             logger.exception('shot')

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -425,7 +425,7 @@ class DownloadBase(ABC):
             if r.status_code == 200:
                 return url
         except HTTPStatusError as e:
-            logger.debug(f'{self.plugin_msg}: url {url}: status_code-{e.response.status_code}')
+            logger.error(f'{self.plugin_msg}: url {url}: status_code-{e.response.status_code}')
         except:
             logger.debug(f'{self.plugin_msg}: url {url}: ', exc_info=True)
         return None

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -74,7 +74,7 @@ class DownloadBase(ABC):
         # 弹幕客户端
         self.danmaku: Optional[IDanmakuClient] = None
 
-        self.plugin_msg = f"{self.__class__.__name__} - {url}"
+        self.plugin_msg = f"[{self.__class__.__name__}]{self.fname} - {url}"
 
     @abstractmethod
     async def acheck_stream(self, is_check=False):
@@ -275,7 +275,7 @@ class DownloadBase(ABC):
                         data += f'\n{os.path.abspath(danmaku_file_name)}'
                     processor(self.segment_processor, data)
                 except:
-                    logger.warning(f'执行后处理失败：{self.__class__.__name__} - {self.fname}', exc_info=True)
+                    logger.warning(f'{self.plugin_msg}: 执行后处理失败', exc_info=True)
 
         thread = threading.Thread(target=x, daemon=True, name=f"segment_processor_{exclude_ext_file_name}")
         prev_thread = self.segment_processor_thread[-1] if self.segment_processor_thread else None
@@ -302,7 +302,7 @@ class DownloadBase(ABC):
                 self.danmaku = None
 
     def start(self):
-        logger.info(f'开始下载: {self.__class__.__name__} - {self.fname}')
+        logger.info(f"{self.plugin_msg}: 开始下载")
         # 开始时间
         start_time = time.localtime()
         # 结束时间
@@ -316,7 +316,7 @@ class DownloadBase(ABC):
             try:
                 ret = self.run()
             except Exception:
-                logger.warning(f'下载失败: {self.__class__.__name__} - {self.fname}', exc_info=True)
+                logger.warning(f"{self.plugin_msg}: 下载失败", exc_info=True)
             finally:
                 self.close()
 
@@ -336,12 +336,12 @@ class DownloadBase(ABC):
 
         for thread in self.segment_processor_thread:
             if thread.is_alive():
-                logger.info(f'等待分段后处理完成: {self.__class__.__name__} - {self.fname} - {thread.name}')
+                logger.info(f'{self.plugin_msg}: 等待分段后处理完成 - {thread.name}')
                 thread.join()
         if (self.is_download and ret) or not self.is_download:
             self.download_success_callback()
         # self.segment_processor_thread
-        logger.info(f'退出下载: {self.__class__.__name__} - {self.fname}')
+        logger.info(f'{self.plugin_msg}: 退出下载')
         stream_info = {
             'name': self.fname,
             'url': self.url,
@@ -388,12 +388,12 @@ class DownloadBase(ABC):
 
                     self.live_cover_path = live_cover_path
                     logger.info(
-                        f'封面下载成功：{self.__class__.__name__} - {self.fname}：{os.path.abspath(self.live_cover_path)}')
+                        f'{self.plugin_msg}: 封面下载成功，路径：{os.path.abspath(self.live_cover_path)}')
                 else:
                     logger.warning(
-                        f'封面下载失败：{self.__class__.__name__} - {self.fname}：封面格式不支持：{self.live_cover_url}')
+                        f'{self.plugin_msg}: 封面为不支持的格式：{self.live_cover_url}')
             except:
-                logger.exception(f'封面下载失败：{self.__class__.__name__} - {self.fname}')
+                logger.exception(f'{self.plugin_msg}: 封面下载失败')
 
     async def acheck_url_healthy(self, url):
         async def __client_get(url, stream: bool = False):
@@ -414,20 +414,20 @@ class DownloadBase(ABC):
                 m3u8_obj = m3u8.loads(r.text)
                 if m3u8_obj.is_variant:
                     url = m3u8_obj.playlists[0].uri
-                    logger.info(f'stream url: {url}')
+                    logger.info(f'{self.plugin_msg}: stream url: {url}')
                     r = await __client_get(url)
             else: # 处理 Flv
                 r = await __client_get(url, stream=True)
                 if r.headers.get('Location'):
                     url = r.headers['Location']
-                    logger.info(f'stream url: {url}')
+                    logger.info(f'{self.plugin_msg}: stream url: {url}')
                     r = await __client_get(url, stream=True)
             if r.status_code == 200:
                 return url
         except HTTPStatusError as e:
-            logger.error(f'url {url}: status_code-{e.response.status_code}')
+            logger.debug(f'{self.plugin_msg}: url {url}: status_code-{e.response.status_code}')
         except:
-            logger.exception(f'url {url}: ')
+            logger.debug(f'{self.plugin_msg}: url {url}: ', exc_info=True)
         return None
 
     def gen_download_filename(self, is_fmt=False):

--- a/biliup/handler.py
+++ b/biliup/handler.py
@@ -33,10 +33,10 @@ logger = logging.getLogger('biliup')
 def pre_processor(name, url):
     url_status = context["PluginInfo"].url_status
     if url_status[url] == 1:
-        logger.debug(f'{name} 正在下载中，跳过下载')
+        logger.debug(f"{name} - {url} 正在下载中，跳过下载")
         return
 
-    logger.info(f'{name} - {url} 开播了准备下载')
+    logger.debug(f"{name} - {url} 开播了准备下载")
     preprocessor = config['streamers'].get(name, {}).get('preprocessor')
     if preprocessor:
         processor(preprocessor, json.dumps({

--- a/biliup/plugins/bilibili.py
+++ b/biliup/plugins/bilibili.py
@@ -177,20 +177,20 @@ class Bililive(DownloadBase):
         if config.get('bili_cdn_fallback'):
             __url = await self.acheck_url_healthy(self.raw_stream_url)
             if __url is None:
-                for cdn, stream_url in target_quality_stream.items():
+                for cdn, stream_info in target_quality_stream.items():
+                    stream_url = stream_info['url']
+                    __fallback_url = normalize_cn204(
+                        f"{stream_url['host']}{stream_url['base_url']}{stream_url['extra']}"
+                    )
                     try:
-                        __url = normalize_cn204(
-                            f"{stream_url['host']}{stream_url['base_url']}{stream_url['extra']}"
-                        )
-                        __url = await self.acheck_url_healthy(__url)
+                        __url = await self.acheck_url_healthy(__fallback_url)
                         if __url is not None:
                             self.raw_stream_url = __url
+                            logger.info(f"{self.plugin_msg}: cdn_fallback 回退到 {cdn} - {__fallback_url}")
                             break
                     except Exception as e:
-                        logger.error(f"{self.plugin_msg}: cdn_fallback {cdn} - {self.raw_stream_url}")
+                        logger.error(f"{self.plugin_msg}: cdn_fallback {e} - {__fallback_url}")
                         continue
-                    finally:
-                        logger.debug(f"{self.plugin_msg}: 回退到 {cdn} - {self.raw_stream_url}")
                 else:
                     logger.error(f"{self.plugin_msg}: 所有 cdn 均不可用")
                     self.raw_stream_url = None

--- a/biliup/plugins/bilibili.py
+++ b/biliup/plugins/bilibili.py
@@ -113,12 +113,16 @@ class Bililive(DownloadBase):
 
         stream_urls = await self.aget_stream(quality_number, protocol, special_type)
         if not stream_urls:
-            if int(time.time()) - live_start_time <= self.__hls_timeout :
-                logger.warning(f"{self.plugin_msg}: 暂未提供 hls_fmp4 流，等待下一次检测")
-                return False
+            if protocol == 'hls_fmp4':
+                if int(time.time()) - live_start_time <= self.__hls_timeout:
+                    logger.warning(f"{self.plugin_msg}: 暂未提供 hls_fmp4 流，等待下一次检测")
+                    return False
+                else:
+                    # 回退首个可用格式
+                    stream_urls = await self.aget_stream(quality_number, 'stream', special_type)
             else:
-                # 回退首个可用格式
-                stream_urls = await self.aget_stream(quality_number, 'stream', special_type)
+                logger.error(f"{self.plugin_msg}: 获取{protocol}流失败")
+                return False
 
         target_quality_stream = stream_urls.get(quality_number, next(iter(stream_urls.values())))
         stream_url = {}

--- a/biliup/plugins/bilibili.py
+++ b/biliup/plugins/bilibili.py
@@ -124,7 +124,9 @@ class Bililive(DownloadBase):
                 logger.error(f"{self.plugin_msg}: 获取{protocol}流失败")
                 return False
 
-        target_quality_stream = stream_urls.get(quality_number, next(iter(stream_urls.values())))
+        target_quality_stream = stream_urls.get(
+            quality_number, next(iter(stream_urls.values()))
+        )
         stream_url = {}
         if perf_cdn is not None:
             for cdn in perf_cdn:

--- a/biliup/plugins/bilibili.py
+++ b/biliup/plugins/bilibili.py
@@ -1,6 +1,7 @@
 import time
 import json
 import re
+import asyncio
 
 from biliup.common.util import client
 from biliup.config import config
@@ -11,14 +12,17 @@ from ..engine.download import DownloadBase
 
 
 OFFICIAL_API = "https://api.live.bilibili.com"
+STREAM_NAME_REGEXP = r"/live-bvc/\d+/(live_[^/\.]+)"
 
 @Plugin.download(regexp=r'(?:https?://)?(b23\.tv|live\.bilibili\.com)')
 class Bililive(DownloadBase):
     def __init__(self, fname, url, suffix='flv'):
         super().__init__(fname, url, suffix)
-        self.live_time = 0
+        self.live_start_time = 0
         self.bilibili_danmaku = config.get('bilibili_danmaku', False)
-        self.fake_headers['referer'] = url
+        self.__real_room_id = None
+        self.__is_login = False
+        # self.fake_headers['referer'] = url
         if config.get('user', {}).get('bili_cookie'):
             self.fake_headers['cookie'] = config.get('user', {}).get('bili_cookie')
         if config.get('user', {}).get('bili_cookie_file'):
@@ -32,92 +36,63 @@ class Bililive(DownloadBase):
                     self.fake_headers['cookie'] = cookies_str
             except Exception:
                 logger.exception("load_cookies error")
-        # else:
-        #    logger.warning("No cookie provided. The original quality may not be available.")
 
     async def acheck_stream(self, is_check=False):
-
-        client.headers.update(self.fake_headers)
 
         if "b23.tv" in self.url:
             try:
                 resp = await client.get(self.url, follow_redirects=False)
                 if resp.status_code not in {301, 302}:
-                    raise
+                    raise Exception("不支持的链接")
                 url = str(resp.next_request.url)
                 if "live.bilibili" not in url:
-                    raise
+                    raise Exception("不支持的链接")
                 self.url = url
-            except:
-                logger.error(f"{self.plugin_msg}: 不支持的链接")
+            except Exception as e:
+                logger.error(f"{self.plugin_msg}: {e}")
                 return False
 
         room_id = match1(self.url, r'bilibili.com/(\d+)')
-        qualityNumber = int(config.get('bili_qn', 10000))
+        quality_number = int(config.get('bili_qn', 10000))
 
         # 获取直播状态与房间标题
         info_by_room_url = f"{OFFICIAL_API}/xlive/web-room/v1/index/getInfoByRoom?room_id={room_id}"
         try:
-            room_info = (await client.get(info_by_room_url)).json()
-        except:
-            logger.exception(f"{self.plugin_msg}: ")
+            room_info = await client.get(info_by_room_url, headers=self.fake_headers)
+            room_info = room_info.json()
+        except Exception as e:
+            logger.error(f"{self.plugin_msg}: {e}")
             return False
         if room_info['code'] != 0:
             logger.error(f"{self.plugin_msg}: {room_info}")
             return False
-        if room_info['data']['room_info']['live_status'] != 1:
+        else:
+            room_info = room_info['data']
+        if room_info['room_info']['live_status'] != 1:
             logger.debug(f"{self.plugin_msg}: 未开播")
             self.raw_stream_url = None
             return False
-        self.live_cover_url = room_info['data']['room_info']['cover']
-        live_start_time = room_info['data']['room_info']['live_start_time']
-        # 允许分段时更新标题
-        self.room_title = room_info['data']['room_info']['title']
-        if live_start_time > self.live_time:
-            self.live_time = live_start_time
+
+        self.live_cover_url = room_info['room_info']['cover']
+        self.room_title = room_info['room_info']['title']
+        self.__real_room_id = room_info['room_info']['room_id']
+        live_start_time = room_info['room_info']['live_start_time']
+        special_type = room_info['room_info']['special_type'] # 0: 公开直播, 1: 大航海专属
+        if live_start_time > self.live_start_time:
+            self.live_start_time = live_start_time
             is_new_live = True
         else:
             is_new_live = False
+
         if is_check:
-            _res = await client.get('https://api.bilibili.com/x/web-interface/nav')
-            try:
-                user_data = json.loads(_res.text).get('data')
-                if user_data.get('isLogin'):
-                    logger.info(f"用户名：{user_data['uname']}, mid：{user_data['mid']}, isLogin：{user_data['isLogin']}")
-                else:
-                    logger.warning(f"{self.plugin_msg}: 未登录，或将只能录制到最低画质。")
-            except:
-                logger.exception(f"{self.plugin_msg}: 登录态校验失败 {_res.text}")
+            self.__is_login = await self.check_login_status()
             return True
 
-        protocol = config.get('bili_protocol', 'stream')
-        perf_cdn = config.get('bili_perfCDN')
-        cdn_fallback = config.get('bili_cdn_fallback', False)
-        force_source = config.get('bili_force_source', False)
-        main_api = config.get('bili_liveapi', OFFICIAL_API).rstrip('/')
-        fallback_api = config.get('bili_fallback_api', OFFICIAL_API).rstrip('/')
-        cn01_sids = config.get('bili_replace_cn01', [])
-        if isinstance(cn01_sids, str):
-            cn01_sids = cn01_sids.split(',')
-        normalize_cn204 = config.get('bili_normalize_cn204', False)
-
-        params = {
-            'room_id': room_id,
-            'protocol': '0,1',  # 0: http_stream, 1: http_hls
-            'format': '0,1,2',  # 0: flv, 1: ts, 2: fmp4
-            'codec': '0',  # 0: avc, 1: hevc, 2: av1
-            'qn': qualityNumber,
-            'platform': 'html5',  # web, html5, android, ios
-            # 'ptype': '8',
-            'dolby': '5',
-            # 'panorama': '1' # 全景(不支持 html5)
-        }
-
-        if self.raw_stream_url is not None \
-                and qualityNumber >= 10000 \
-                and not is_new_live:
-            # 同一个 streamName 即可复用，除非被超管切断
-            # 前面拿不到 streamName，目前使用开播时间判断
+        # 复用原画 m3u8 流
+        if  self.raw_stream_url is not None \
+            and ".m3u8" in self.raw_stream_url \
+            and quality_number >= 10000 \
+            and not is_new_live:
             url = await self.acheck_url_healthy(self.raw_stream_url)
             if url is not None:
                 logger.debug(f"{self.plugin_msg}: 复用 {url}")
@@ -125,141 +100,294 @@ class Bililive(DownloadBase):
             else:
                 self.raw_stream_url = None
 
-        try:
-            play_info = await self._get_play_info(main_api, params)
-            if not play_info or check_areablock(play_info):
-                logger.debug(f"{self.plugin_msg}: {main_api} 返回 {play_info}")
-                play_info = await self._get_play_info(fallback_api, params)
-                if not play_info or check_areablock(play_info):
-                    logger.debug(f"{self.plugin_msg}: {fallback_api} 返回 {play_info}")
-                    return False
-        except Exception:
-            logger.exception(f"{self.plugin_msg}: ")
-            return False
-        if play_info['code'] != 0:
-            logger.error(f"{self.plugin_msg}: {play_info}")
-            return False
+        protocol = config.get('bili_protocol', 'stream')
+        perf_cdn = config.get('bili_perfCDN')
+        perf_cdn = config.get('bili_cdn', perf_cdn.split(',') if isinstance(perf_cdn, str) else [])
+        self.__hls_timeout = config.get('bili_hls_transcode_timeout', 60)
 
-        streams = play_info['data']['playurl_info']['playurl']['stream']
-        stream = streams[1] if protocol.startswith('hls') and len(streams) > 1 else streams[0]
-        stream_format = stream['format'][0]
-        if protocol == "hls_fmp4":
-            if stream_format['format_name'] != 'fmp4':
-                if len(stream['format']) > 1:
-                    stream_format = stream['format'][1]
-                elif int(time.time()) - live_start_time <= 60:
-                    logger.warning(f"{self.plugin_msg}: 暂时未提供 hls_fmp4 流，等待下一次检测")
-                    return False
-                else:
-                    # hls_ts 大抵是无了，只能回退 Flv
-                    stream_format = streams[0]['format'][0]
-                    logger.info(f"{self.plugin_msg}: 已切换为 stream 流")
-        stream_info = stream_format['codec'][0]
-        # 防止 hls_fmp4 不转码原画
-        if qualityNumber == 10000 \
-            and qualityNumber not in stream_info['accept_qn'] \
-            and stream['protocol_name'] != streams[0]['protocol_name']:
-            stream_info = streams[0]['format'][0]['codec'][0]
-            logger.warning(
-                f"{self.plugin_msg}: 当前 protocol-{protocol} 未提供原画，尝试回退到 stream 流"
-            )
+        normalize_url = lambda a: a if a.startswith(('http://', 'https://')) else 'http://' + a
+        self.__api_list = [
+            normalize_url(config.get('bili_liveapi', OFFICIAL_API)).rstrip('/'),
+            normalize_url(config.get('bili_fallback_api', OFFICIAL_API)).rstrip('/'),
+        ]
 
-        stream_url = {
-            'base_url': stream_info['base_url'],
-        }
+        stream_urls = await self.aget_stream(quality_number, protocol, special_type)
+        if not stream_urls:
+            if int(time.time()) - live_start_time <= self.__hls_timeout :
+                logger.warning(f"{self.plugin_msg}: 暂未提供 hls_fmp4 流，等待下一次检测")
+                return False
+            else:
+                # 回退首个可用格式
+                stream_urls = await self.aget_stream(quality_number, 'stream', special_type)
+
+        target_quality_stream = stream_urls.get(quality_number, next(iter(stream_urls.values())))
+        stream_url = {}
         if perf_cdn is not None:
-            perf_cdn_list = perf_cdn.split(',')
-            for url_info in stream_info['url_info']:
-                if 'host' in stream_url:
+            for cdn in perf_cdn:
+                stream_info = target_quality_stream.get(cdn)
+                if stream_info is not None:
+                    current_cdn = cdn
+                    stream_url = stream_info['url']
                     break
-                for cdn in perf_cdn_list:
-                    if cdn in url_info['extra']:
-                        stream_url['host'] = url_info['host']
-                        stream_url['extra'] = url_info['extra']
-                        logger.debug(f"Found {stream_url['host']}")
-                        break
-        if len(stream_url) < 3:
-            stream_url['host'] = stream_info['url_info'][-1]['host']
-            stream_url['extra'] = stream_info['url_info'][-1]['extra']
+        if not stream_url:
+            current_cdn, stream_info = next(iter(target_quality_stream.items()))
+            stream_url = stream_info['url']
+            logger.debug(f"{self.plugin_msg}: 使用 {current_cdn} 流")
 
-        # 移除 streamName 内画质标签
-        if force_source:
-            streamname_regexp = r"(live_\d+_\w+_\w+_?\w+?)"  # 匹配 streamName
-            streamName = match1(stream_url['base_url'], streamname_regexp)
-            if streamName is not None and qualityNumber >= 10000:
-                _base_url = stream_url['base_url'].replace(f"_{streamName.split('_')[-1]}", '')
-                if (await self.acheck_url_healthy(f"{stream_url['host']}{_base_url}{stream_url['extra']}")) is not None:
-                    stream_url['base_url'] = _base_url
-                else:
-                    logger.debug(f"{self.plugin_msg}: force_source {_base_url}")
-
+        # 替换 cn-gotcha01 节点
+        cn01_sids = config.get('bili_replace_cn01', [])
         if cn01_sids:
-            if "cn-gotcha01" in stream_url['extra']:
+            if isinstance(cn01_sids, str): cn01_sids = cn01_sids.split(',')
+            if "cn-gotcha01" in current_cdn:
                 for sid in cn01_sids:
-                    _host = f"https://{sid}.bilivideo.com"
-                    url = f"{_host}{stream_url['base_url']}{stream_url['extra']}"
-                    if (await self.acheck_url_healthy(url)) is not None:
-                        stream_url['host'] = _host
+                    __host = f"https://{sid}.bilivideo.com"
+                    __url = f"{__host}{stream_url['base_url']}{stream_url['extra']}"
+                    if (await self.acheck_url_healthy(__url)) is not None:
+                        stream_url['host'] = __host
                         break
                     else:
                         logger.debug(f"{self.plugin_msg}: {sid} is not available")
 
-        self.raw_stream_url = f"{stream_url['host']}{stream_url['base_url']}{stream_url['extra']}"
+        # 强制原画
+        if quality_number == 10000 and config.get('bili_force_source'):
+            if stream_info['suffix'] != 'origin':
+                __base_url = stream_url['base_url'].replace(f"_{stream_info['suffix']}", "")
+                __sk = match1(stream_url['extra'], r'sk=([^&]+)')
+                __extra = stream_url['extra'].replace(__sk, __sk[:32])
+                __url = normalize_cn204(f"{stream_url['host']}{__base_url}{__extra}")
+                if (await self.acheck_url_healthy(__url)) is not None:
+                    self.raw_stream_url = __url
+                    logger.info(f"{self.plugin_msg}: force_source 处理 {current_cdn} 成功 {stream_info['stream_name']}")
+                else:
+                    logger.debug(
+                        f"{self.plugin_msg}: force_source 处理 {current_cdn} 失败 {stream_info['stream_name']}"
+                    )
 
-        if normalize_cn204:
-            self.raw_stream_url = re.sub(r"(?<=cn-gotcha204)-[1-4]", "", self.raw_stream_url, 1)
+        if not self.raw_stream_url:
+            self.raw_stream_url = normalize_cn204(
+                f"{stream_url['host']}{stream_url['base_url']}{stream_url['extra']}"
+            )
 
-        if cdn_fallback:
-            _url = await self.acheck_url_healthy(self.raw_stream_url)
-            if _url is None:
-                i = len(stream_info['url_info'])
-                while i:
-                    i -= 1
+        if config.get('bili_cdn_fallback'):
+            __url = await self.acheck_url_healthy(self.raw_stream_url)
+            if __url is None:
+                for cdn, stream_url in target_quality_stream.items():
                     try:
-                        self.raw_stream_url = "{}{}{}".format(stream_info['url_info'][i]['host'],
-                                                              stream_url['base_url'],
-                                                              stream_info['url_info'][i]['extra'])
-                        _url = await self.acheck_url_healthy(self.raw_stream_url)
-                        if _url is not None:
-                            self.raw_stream_url = _url
+                        __url = normalize_cn204(
+                            f"{stream_url['host']}{stream_url['base_url']}{stream_url['extra']}"
+                        )
+                        __url = await self.acheck_url_healthy(__url)
+                        if __url is not None:
+                            self.raw_stream_url = __url
                             break
-                    except:
-                        logger.exception("Uncaught exception:")
+                    except Exception as e:
+                        logger.error(f"{self.plugin_msg}: cdn_fallback {cdn} - {self.raw_stream_url}")
                         continue
                     finally:
-                        logger.debug(f"{i} - {self.raw_stream_url}")
+                        logger.debug(f"{self.plugin_msg}: 回退到 {cdn} - {self.raw_stream_url}")
                 else:
-                    logger.debug(play_info)
+                    logger.error(f"{self.plugin_msg}: 所有 cdn 均不可用")
                     self.raw_stream_url = None
                     return False
             else:
-                self.raw_stream_url = _url
+                self.raw_stream_url = __url
 
         return True
 
     def danmaku_init(self):
         if self.bilibili_danmaku:
-            self.danmaku = DanmakuClient(self.url, self.gen_download_filename())
+            self.danmaku = DanmakuClient(
+                self.url, self.gen_download_filename(), {'room_id': self.__real_room_id}
+            )
 
-
-    async def _get_play_info(self, api, params) -> dict:
-        api = (lambda a: a if a.startswith(('http://', 'https://')) else 'http://' + a)(api)
+    async def get_play_info(self, api: str, qn: int = 10000) -> dict:
         full_url = f"{api}/xlive/web-room/v2/index/getRoomPlayInfo"
+        params = {
+            'room_id': self.__real_room_id,
+            'protocol': '0,1',  # 流协议，0: http_stream(flv), 1: http_hls
+            'format': '0,1,2',  # 编码格式，0: flv, 1: ts, 2: fmp4
+            'codec': '0',  # 编码器，0: avc, 1: hevc, 2: av1
+            'qn': qn,
+            'platform': 'html5',  # 平台名称，web, html5, android, ios
+            # 'ptype': '8', # P2P配置，-1: disable, 8: WebRTC, 8192: MisakaTunnel
+            'dolby': '5', # 杜比格式，5: 杜比音频
+            # 'panorama': '1', # 全景(不支持 html5)
+            # 'http': '1', # 优先 http 协议
+        }
         try:
-            _info = await client.get(full_url, params=params)
-            return json.loads(_info.text)
-        except:
-            logger.exception(f"{params['room_id']} <- {api} 返回内容错误: {_info.text}")
+            api_res = await client.get(
+                full_url, params=params, headers=self.fake_headers
+            )
+            api_res = json.loads(api_res.text)
+            if api_res['code'] != 0:
+                logger.error(f"{self.plugin_msg}: {api} 返回内容错误: {api_res}")
+                return {}
+            return api_res['data']
+        except json.JSONDecodeError:
+            logger.error(f"{self.plugin_msg}: {api} 返回内容错误: {api_res.text}")
+        except Exception as e:
+            logger.error(f"{self.plugin_msg}: {api} 获取 play_info 失败 -> {e}", exc_info=True)
         return {}
 
+    async def get_master_m3u8(self, api: str) -> dict:
+        full_url = f"{api}/live-bvc/master.m3u8"
+        params = {
+            "cid": self.__real_room_id,
+            # "mid": {self.__login_info.get('mid')},
+            "pt": "html5", # platform
+            # "p2p_type": "-1",
+        }
+        try:
+            m3u8_res = await client.get(
+                full_url, params=params, headers=self.fake_headers
+            )
+            if m3u8_res.status_code == 200 and m3u8_res.text.startswith("#EXTM3U"):
+                return parse_master_m3u8(m3u8_res.text)
+        except Exception as e:
+            logger.error(f"{self.plugin_msg}: {api} 获取 m3u8 失败 -> {e}", exc_info=True)
+        return {}
+
+    async def aget_stream(self, qn: int = 10000, protocol: str = 'stream', special_type: int = 0) -> dict:
+        """
+        :param qn: 目标画质
+        :param protocol: 流协议
+        :param special_type: 特殊直播类型
+        :return: 流信息
+        """
+        stream_urls = {}
+        for api in self.__api_list:
+            play_info = await self.get_play_info(api, qn)
+            if not play_info or check_areablock(play_info):
+                # logger.error(f"{self.plugin_msg}: {api} 返回内容错误: {play_info}")
+                continue
+            streams = play_info['playurl_info']['playurl']['stream']
+            if protocol == 'hls_fmp4':
+                if config.get('bili_anonymous_origin'):
+                    # 开播检测运行在主线程，拿不到保存的登录状态
+                    if special_type in play_info['all_special_types']:
+                        logger.warn(f"{self.plugin_msg}: 特殊直播{special_type}")
+                    else:
+                        stream_urls = await self.get_master_m3u8(api)
+                        if stream_urls:
+                            break
+                # 处理 API 信息
+                stream = streams[1] if len(streams) > 1 else streams[0]
+                for format in stream['format']:
+                    if format['format_name'] == 'fmp4':
+                        stream_urls = parse_stream_url(format['codec'][0])
+                        # fmp4 可能没有原画
+                        if qn == 10000 and qn in stream_urls.keys():
+                            break
+                        else:
+                            stream_urls = {}
+            else:
+                stream_urls = parse_stream_url(streams[0]['format'][0]['codec'][0])
+            if stream_urls:
+                break
+        # 空字典照常返回，重试交给上层方法处理
+        return stream_urls
+
+    async def check_login_status(self):
+        """检查B站登录状态"""
+        try:
+            _res = await client.get('https://api.bilibili.com/x/web-interface/nav', headers=self.fake_headers)
+            user_data = json.loads(_res.text).get('data', {})
+            if user_data.get('isLogin'):
+                logger.info(f"用户名：{user_data['uname']}, mid：{user_data['mid']}, isLogin：{user_data['isLogin']}")
+                return True
+            else:
+                logger.warning(f"{self.plugin_msg}: 未登录，或将只能录制到最低画质。")
+        except Exception as e:
+            logger.error(f"{self.plugin_msg}: 登录态校验失败 {e}")
+        return False
 
 # Copy from room-player.js
 def check_areablock(data):
     '''
     :return: True if area block
     '''
-    if not data['data']['playurl_info']['playurl']:
+    if not data['playurl_info']['playurl']:
         logger.error('Sorry, bilibili is currently not available in your country according to copyright restrictions.')
         logger.error('非常抱歉，根据版权方要求，您所在的地区无法观看本直播')
         return True
     return False
+
+def normalize_cn204(url: str) -> str:
+    if config.get('bili_normalize_cn204') and "cn-gotcha204" in url:
+        return re.sub(r"(?<=cn-gotcha204)-[1-4]", "", url, 1)
+    return url
+
+
+def parse_stream_url(*args) -> dict:
+    ov2cn = config.get('bili_ov2cn', False)
+    suffix_regexp = r'suffix=([^&]+)'
+    if isinstance(args[0], str):
+        url = args[0]
+        host = "https://" + match1(url, r'https?://([^/]+)')
+        stream_url = {
+            'host': host if not ov2cn else host.replace("ov-", "cn-"),
+            'base_url': url.split("?")[0].split(host)[1] + "?",
+            'extra': url.split("?")[1]
+        }
+        return {
+            'url': stream_url,
+            'stream_name': match1(url, STREAM_NAME_REGEXP),
+            'suffix': match1(url, suffix_regexp)
+        }
+    elif isinstance(args[0], dict):
+        streams = {}
+        current_qn = args[0]['current_qn']
+        streams.setdefault(current_qn, {})
+        base_url = args[0]['base_url']
+        for info in args[0]['url_info']:
+            cdn_name = match1(info['extra'], r'cdn=([^&]+)')
+            stream_url = {
+                'host': info['host'] if not ov2cn else info['host'].replace("ov-", "cn-"),
+                'base_url': base_url,
+                'extra': info['extra']
+            }
+            streams[current_qn].setdefault(cdn_name, {
+                'url': stream_url,
+                'stream_name': match1(base_url, STREAM_NAME_REGEXP),
+                'suffix': match1(info['extra'], suffix_regexp)
+            })
+        return streams
+
+
+def parse_master_m3u8(m3u8_content: str) -> dict:
+    """
+    Returns:
+        {
+            "qn值": {
+                "cdn名称": {
+                    "url": parsed_stream_url,
+                    "stream_name": "流名称",
+                    "suffix": "二压后缀"
+                }
+            }
+        }
+    """
+    lines = m3u8_content.strip().splitlines()
+    current_qn = None
+    result = {}
+
+    if not lines[0].startswith('#EXTM3U'):
+        raise ValueError('Invalid m3u8 file')
+
+    for line in lines:
+        if line.startswith('#EXT-X-STREAM-INF:'):
+            codec = match1(line, r'CODECS="([^"]+)"')
+            current_qn = match1(line, r'BILI-QN=(\d+)')
+
+            if codec and current_qn:
+                if 'avc' in codec.lower():
+                    result.setdefault(current_qn, {})
+                else:
+                    current_qn = None
+
+        elif line.startswith('http') and current_qn is not None:
+            cdn_name = match1(line, r'cdn=([^&]+)')
+            if cdn_name:
+                result[current_qn].setdefault(cdn_name, parse_stream_url(line))
+
+    return dict(sorted(result.items(), key=lambda x: int(x[0]), reverse=True))

--- a/biliup/plugins/douyin.py
+++ b/biliup/plugins/douyin.py
@@ -39,16 +39,19 @@ class Douyin(DownloadBase):
                 if resp.status_code not in {301, 302}:
                     raise
                 next_url = str(resp.next_request.url)
-                if "webcast.amemv" not in next_url:
+                if "webcast.amemv" in next_url:
+                    self.__sec_uid = match1(next_url, r"sec_user_id=(.*?)&")
+                    self.__room_id = match1(next_url.split("?")[0], r"(\d+)")
+                elif "isedouyin.com/share/user" in next_url:
+                    self.__sec_uid = match1(next_url, r"sec_uid=(.*?)&")
+                else:
                     raise
             except:
                 logger.error(f"{self.plugin_msg}: 不支持的链接")
                 return False
-            self.__sec_uid = match1(next_url, r"sec_user_id=(.*?)&")
-            self.__room_id = match1(next_url.split("?")[0], r"(\d+)")
         elif "/user/" in self.url:
             sec_uid = self.url.split("user/")[1].split("?")[0]
-            if len(sec_uid) == 55:
+            if len(sec_uid) in {55, 76}:
                 self.__sec_uid = sec_uid
             else:
                 try:

--- a/biliup/plugins/douyin.py
+++ b/biliup/plugins/douyin.py
@@ -73,7 +73,7 @@ class Douyin(DownloadBase):
             self.__web_rid = web_rid
 
         try:
-            _room_info = None
+            _room_info = {}
             if self.__web_rid:
                 _room_info = await self.get_web_room_info(self.__web_rid)
                 if _room_info:
@@ -108,7 +108,7 @@ class Douyin(DownloadBase):
 
         try:
             pull_data = room_info['stream_url']['live_core_sdk_data']['pull_data']
-            if room_info['stream_url'].get('pull_datas') and config.get('douyin_extra_record', True):
+            if room_info['stream_url'].get('pull_datas') and config.get('douyin_double_screen', False):
                 pull_data = next(iter(room_info['stream_url']['pull_datas'].values()))
             stream_data = json.loads(pull_data['stream_data'])['data']
         except:
@@ -149,7 +149,7 @@ class Douyin(DownloadBase):
                     quality = optional_quality_items[optional_quality_index - 1]
 
             protocol = 'hls' if config.get('douyin_protocol') == 'hls' else 'flv'
-            self.raw_stream_url = stream_data[quality]['main'][protocol]
+            self.raw_stream_url = stream_data[quality]['main'][protocol].replace('http://', 'https://')
             self.room_title = room_info['title']
         except:
             logger.exception(f"{self.plugin_msg}: 寻找清晰度失败")

--- a/biliup/web/__init__.py
+++ b/biliup/web/__init__.py
@@ -80,19 +80,18 @@ async def get_streamer_config(request):
     return web.json_response(config.data['streamers'])
 
 
-async def set_streamer_config(request):
-    post_data = await request.json()
-    # config.data['streamers'] = post_data['streamers']
-    for i, j in post_data['streamers'].items():
-        if i not in config.data['streamers']:
-            config.data['streamers'][i] = {}
-        for key, Value in j.items():
-            config.data['streamers'][i][key] = Value
-    for i in config.data['streamers']:
-        if i not in post_data['streamers']:
-            del config.data['streamers'][i]
-
-    return web.json_response({"status": 200}, status=200)
+# async def set_streamer_config(request):
+#     post_data = await request.json()
+#     # config.data['streamers'] = post_data['streamers']
+#     for i, j in post_data['streamers'].items():
+#         if i not in config.data['streamers']:
+#             config.data['streamers'][i] = {}
+#         for key, Value in j.items():
+#             config.data['streamers'][i][key] = Value
+#     for i in config.data['streamers']:
+#         if i not in post_data['streamers']:
+#             del config.data['streamers'][i]
+#     return web.json_response({"status": 200}, status=200)
 
 
 async def save_config(request):
@@ -125,15 +124,27 @@ async def cookie_login(request):
     return web.json_response({"status": 200})
 
 
-async def sms_login(request):
-    pass
+# async def sms_login(request):
+#     pass
 
 
-async def sms_send(request):
-    # post_data = await request.json()
+# async def sms_send(request):
+#     # post_data = await request.json()
 
-    pass
+#     pass
 
+
+def check_similar_remark(json_data):
+    '''
+    :return: True if similar remark exists
+    '''
+    for fname in config['streamers'].keys():
+        if (
+            json_data['remark'] in fname or
+            fname in json_data['remark']
+        ):
+            return True
+    return False
 
 @routes.get('/v1/get_qrcode')
 async def qrcode_get(request):
@@ -245,6 +256,8 @@ async def streamers(request):
 async def add_lives(request):
     from biliup.app import context
     json_data = await request.json()
+    if check_similar_remark(json_data):
+        return web.HTTPBadRequest(text=f"{json_data['remark']} 与现存备注存在部分重复，禁止添加")
     uid = json_data.get('upload_id')
     with SessionLocal() as db:
         if uid:
@@ -269,9 +282,15 @@ async def lives(request):
     from biliup.app import context
     json_data = await request.json()
     # old = LiveStreamers.get_by_id(json_data['id'])
+    # if check_similar_remark(json_data):
+    #     return web.HTTPBadRequest(text=f"{json_data['remark']} 与现存备注存在部分重复，禁止修改")
     with SessionLocal() as db:
         old = db.get(LiveStreamers, json_data['id'])
         old_url = old.url
+        # 如果备注修改，才需要检查是否与现存备注存在部分重复
+        if json_data['remark'] != old.remark:
+            if check_similar_remark(json_data):
+                return web.HTTPBadRequest(text=f"{json_data['remark']} 与现存备注存在部分重复，禁止修改")
         uid = json_data.get('upload_id')
         # semi-ui 不能直接为 ArrayField 设置空默认值
         # 当前端更新后，应移除这里的数据修改
@@ -558,10 +577,10 @@ async def service(args):
         web.get('/api/basic', get_basic_config),
         web.post('/api/setbasic', set_basic_config),
         web.get('/api/getconfig', get_streamer_config),
-        web.post('/api/setconfig', set_streamer_config),
+        # web.post('/api/setconfig', set_streamer_config),
         web.get('/api/login_by_cookie', cookie_login),
-        web.get('/api/login_by_sms', sms_login),
-        web.post('/api/send_sms', sms_send),
+        # web.get('/api/login_by_sms', sms_login),
+        # web.post('/api/send_sms', sms_send),
         web.get('/api/save', save_config),
         # web.get('/api/get_qrcode', qrcode_get),
         # web.post('/api/login_by_qrcode', qrcode_login),

--- a/public/config.toml
+++ b/public/config.toml
@@ -95,7 +95,7 @@ check_sourcecode = 15
 ### 由于ffmpeg只能单线程下载，并且stream-gears录制有问题，所以目前fmp4流只能使用streamlink+ffmpeg混合模式。
 #bili_protocol = "stream"
 ### 哔哩哔哩直播优选CDN，默认无
-#bili_perfCDN = "cn-gotcha208,ov-gotcha05"
+#bili_cdn = ["cn-gotcha208", "ov-gotcha05"]
 ### 哔哩哔哩强制真原画（仅限TS与FMP4流的 cn-gotcha01 CDN，且 bili_qn >= 10000），默认为关闭
 ### 不保证可用性。当无法强制获取到真原画时，将会自动回退到二压原画。
 #bili_force_source = false

--- a/public/config.yaml
+++ b/public/config.yaml
@@ -94,7 +94,7 @@ check_sourcecode: 15
 ### 由于ffmpeg只能单线程下载，并且stream-gears录制有问题，所以目前fmp4流只能使用streamlink+ffmpeg混合模式。
 #bili_protocol: stream
 ### 哔哩哔哩直播优选CDN，默认无，支持同时填入多个CDN节点。
-#bili_perfCDN: 'cn-gotcha208,ov-gotcha05'
+#bili_cdn: [cn-gotcha204, ov-gotcha05]
 ### 哔哩哔哩强制真原画（仅限TS与FMP4流的 cn-gotcha01 CDN，且 bili_qn >= 10000），默认为关闭
 ### 不保证可用性。当无法强制获取到真原画时，将会自动回退到二压原画。
 #bili_force_source: false
@@ -113,12 +113,7 @@ check_sourcecode: 15
 ### 海外机的玩法：配合一个国内的机器（例如便宜的腾讯云，阿里云等等）自建反代api.live.bilibili.com。或者使用https://docs.qq.com/doc/DV2dvbXBrckNscU9x 此处提供的公用反代API。
 ### 如果海外机到联通或者移动网络线路还不错，就可以参考***完整CDN列表***选取一些联通或者移动的节点并填入下面
 ### 每次会随机返回填入的其中一个线路，并且会自动判断所填入的节点是否可用
-#bili_replace_cn01:
-    # - cn-jxnc-cm-01-16
-    # - cn-gddg-cm-01-06
-    # - cn-fjqz-cm-01-06
-    # - cn-jssz-cm-01-02
-    # - cn-gddg-ct-01-12
+#bili_replace_cn01: [cn-tj-cm-01-03, cn-gddg-cm-01-03, cn-fjqz-cm-01-03, cn-jssz-cm-02-26, cn-gdfs-ct-01-12]
 ### 哔哩哔哩自选画质
 ### 刚开播可能没有除了原画之外的画质 会先录制原画 后续视频分段(仅ffmpeg streamlink)时录制设置的画质
 ### 30000 杜比,20000 4K,10000 原画,401 蓝光(杜比),400 蓝光,250 超清,150 高清,80 流畅,0 B站默认(多数情况下是蓝光 400)


### PR DESCRIPTION
## 新增
 - `bili_ov2cn`: 将海外CDN域名替换为大陆CDN域名。
 - `bili_anonymous_origin`: 免登录录制`hls_fmp4`原画。
 - `bili_hls_transcode_timeout`: `hls_fmp4`转码超时时间。
 - `douyin_double_screen`: 控制抖音双屏直播录制方式。resolves #1100
 - `webui(录播管理)`: 校验相似录播备注。resolves #1086

## 更改
 - `bili_perfCDN`: 更名为`bili_cdn`，以匹配其他平台选项名称。
 - `webui(哔哩哔哩)`: 调整部分选项位置。
 - `plugin`: 减少无用日志输出。

## 修复
 - `bili_force_source`: 修复因`sk`参数过长导致的验证失败。
 - `douyin`: fixes #1105 部分抖音用户 sec_user_id 更新至 76 位。

## 移除
 - `bili_protocol`: 因`哔哩哔哩APP(粉版/大陆版/大陆商店版)`已移除对`hls_ts`的支持，跟进官方处理。