### PR TITLE
B站弹幕部分的参数兼容DanmakuFactory可识别用户名

### DIFF
--- a/biliup/Danmaku/__init__.py
+++ b/biliup/Danmaku/__init__.py
@@ -191,40 +191,40 @@ class DanmakuClient(IDanmakuClient):
                         return
                     # 弹幕信息记录
                     elif m.get('msg_type') == 'danmaku':
-                      try:
-                          if m.get('color'):
-                              color = m["color"]
-                          else:
-                              color = '16777215'
-                          msg_time = format(time.time() - start_time, '.3f')
-                          # 记录弹幕额外信息
-                          timestamp = str(int(time.time()))
-                          uid = str(m.get("uid",0))
-                          d = etree.SubElement(root, 'd')
-                          '''
-                          弹幕部分的参数兼容bilibili主站弹幕 XML 文件，按顺序含义分别为：
-                          1.弹幕出现时间 (秒)
-                          2.弹幕类型
-                          3.字号
-                          4.颜色
-                          5.发送时间戳
-                          6.固定为 0 (主站弹幕 XML 为弹幕池 ID)
-                          7.发送者 UID (主站弹幕 XML 为发送用户 ID 的 CRC32)
-                          8.固定为 0 (主站弹幕 XML 为弹幕的数据库 ID)
-                          '''
-                          if self.__content.get("detail", None):
-                              d.set('p', f"{msg_time},1,25,{color},{timestamp},0,{uid},0")
-                              d.set('timestamp', timestamp)
-                              d.set('uid',uid)
-                              #兼容DanmakuFactory可识别用户名
-                              d.set('user', m.get("name",""))
-                              d.text = m["content"]
-                          else:
-                              d.set('p', f"{msg_time},1,25,{color},0,0,0,0")
-                      except:
-                          logger.warning(f"{DanmakuClient.__name__}:{self.__url}:弹幕处理异常", exc_info=True)
-                          # 异常后略过本次弹幕
-                          continue
+                        try:
+                            if m.get('color'):
+                                color = m["color"]
+                            else:
+                                color = '16777215'
+                            msg_time = format(time.time() - start_time, '.3f')
+                            # 记录弹幕额外信息
+                            timestamp = str(int(time.time()))
+                            uid = str(m.get("uid",0))
+                            d = etree.SubElement(root, 'd')
+                            '''
+                            弹幕部分的参数兼容bilibili主站弹幕 XML 文件，按顺序含义分别为：
+                            1.弹幕出现时间 (秒)
+                            2.弹幕类型
+                            3.字号
+                            4.颜色
+                            5.发送时间戳
+                            6.固定为 0 (主站弹幕 XML 为弹幕池 ID)
+                            7.发送者 UID (主站弹幕 XML 为发送用户 ID 的 CRC32)
+                            8.固定为 0 (主站弹幕 XML 为弹幕的数据库 ID)
+                            '''
+                            if self.__content.get("detail", None):
+                                d.set('p', f"{msg_time},1,25,{color},{timestamp},0,{uid},0")
+                                d.set('timestamp', timestamp)
+                                d.set('uid',uid)
+                                #兼容DanmakuFactory可识别用户名
+                                d.set('user', m.get("name",""))
+                                d.text = m["content"]
+                            else:
+                                d.set('p', f"{msg_time},1,25,{color},0,0,0,0")
+                        except:
+                            logger.warning(f"{DanmakuClient.__name__}:{self.__url}:弹幕处理异常", exc_info=True)
+                            # 异常后略过本次弹幕
+                            continue
                     # 礼物信息记录，支持上舰、SC、礼物，目前仅在B站开启
                     elif m.get('msg_type') in ['gift', 'super_chat' , 'guard_buy'] and self.__u == 'live.bilibili.com':
                         if not self.__content.get("detail", None):

--- a/biliup/Danmaku/__init__.py
+++ b/biliup/Danmaku/__init__.py
@@ -214,8 +214,8 @@ class DanmakuClient(IDanmakuClient):
                           '''
                           if self.__content.get("detail", None):
                               d.set('p', f"{msg_time},1,25,{color},{timestamp},0,{uid},0")
-                              d.set('timestamp', str(int(time.time())))
-                              d.set('uid', str(m.get("uid",0)))
+                              d.set('timestamp', timestamp)
+                              d.set('uid',uid)
                               #兼容DanmakuFactory可识别用户名
                               d.set('user', m.get("name",""))
                               d.text = m["content"]


### PR DESCRIPTION
参考弹幕p部分的参数兼容 bilibili 主站弹幕 XML 文件，按顺序含义分别为：
1.弹幕出现时间 (秒)
2.弹幕类型
3.字号
4.颜色
5.发送时间戳
6.固定为 0 (主站弹幕 XML 为弹幕池 ID)
7.发送者 UID (主站弹幕 XML 为发送用户 ID 的 CRC32)
8.固定为 0 (主站弹幕 XML 为弹幕的数据库 ID)
同时修改发送者昵称为user，以兼容DanmakuFactory可识别用户名