### PR TITLE
Update dependencies and Python version requirements

### DIFF
--- a/biliup/__init__.py
+++ b/biliup/__init__.py
@@ -2,7 +2,7 @@ import logging
 import platform
 import sys
 
-__version__ = "0.4.86"
+__version__ = "0.4.87"
 
 LOG_CONF = {
     'version': 1,

--- a/biliup/common/util.py
+++ b/biliup/common/util.py
@@ -1,24 +1,31 @@
 import asyncio
-import ssl
-import truststore
+
 import httpx
 from datetime import datetime, time, timezone, timedelta
 from biliup.config import config
 import logging
 
+try:
+    import ssl
+    import truststore # type: ignore
+except ImportError:
+    ssl = None
+    truststore = None
+    _ssl_context = True
+else:
+    _ssl_context = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
 # This setup works very well on my Swedish machine, but who knows about others...
 DEFAULT_TIMEOUT = httpx.Timeout(timeout=15.0, connect=10.0)
 DEFAULT_MAX_RETRIES = 2
 DEFAULT_CONNECTION_LIMITS = httpx.Limits(max_connections=100, max_keepalive_connections=100)
 
-ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 client = httpx.AsyncClient(
     http2=True,
     follow_redirects=True,
     timeout=DEFAULT_TIMEOUT,
     limits=DEFAULT_CONNECTION_LIMITS,
-    verify=ctx
+    verify=_ssl_context
 )
 loop = asyncio.get_running_loop()
 logger = logging.getLogger('biliup')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['pip>=20.3', 'setuptools>=62', 'wheel']
+requires = ['pip>=24.2', 'setuptools>=74', 'wheel']
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,30 +8,29 @@ authors = [{ name = "ForgQi" }]
 description = "stream download and upload"
 keywords = ["bilibili douyu huya"]
 urls = { Homepage = "https://github.com/ForgQi/bilibiliupload" }
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 dependencies = [
     "tomli-w>=1.0.0",
     "stream-gears >= 0.2.2,<0.3",
     "psutil >= 5.4.6",
     "aiofiles >= 22.1.0",
-    "yt-dlp >= 2024.7.9",
+    "yt-dlp >= 2025.2.19",
     "Pillow >= 5.2.0",
-    "aiohttp[speedups]",
-    "aiohttp-cors",
-    "Requests >= 2.20.0",
-    "httpx[http2] >= 0.27.0",
-    "httpcore > 1.0.3",
+    "aiohttp[speedups] < 3.10.0", # aio-libs/aiohttp#10519
+    "aiohttp_cors >= 0.7.0",
+    "requests >= 2.32.3",
+    "httpx[http2] >= 0.28.1",
+    "httpcore >= 1.0.7",
     "PyYAML >= 4.2b1",
-    "streamlink >= 6.8.3",
+    "streamlink >= 7.1.3",
     "ykdl >= 1.8.0",
     "rsa >= 4.6",
-    "importlib-resources; python_version < '3.9'",
-    "tomli >= 1.1.0 ; python_version < '3.11'",
+    "tomli >= 1.1.0; python_version < '3.11'",
     "protobuf >= 4.23.0",
-    "SQLAlchemy>=2.0.0",
-    "alembic>=1.12.1",
-    "m3u8",
-    "truststore",
+    "SQLAlchemy >= 2.0.0",
+    "alembic >= 1.12.1",
+    "m3u8 >= 6.0.0",
+    "truststore >= 0.10.1; python_version >= '3.10'",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
- 提升 Python Version 依赖到 >= 3.9
- 更新依赖版本
- 缓解由 aiohttp 新版引入的[问题](https://github.com/aio-libs/aiohttp/issues/10519)
- 在 Python >=3.10 时默认信任系统证书，其他版本默认使用 certifi