### PR TITLE
fix: 回归下载器选择streamlink时的正常行为

### DIFF
--- a/biliup/__init__.py
+++ b/biliup/__init__.py
@@ -2,7 +2,7 @@ import logging
 import platform
 import sys
 
-__version__ = "0.4.88"
+__version__ = "0.4.89"
 
 LOG_CONF = {
     'version': 1,

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -205,6 +205,7 @@ class DownloadBase(ABC):
                 '-c',
                 'copy',
             ]
+            # https://github.com/biliup/biliup/issues/991
             if use_streamlink and not self.raw_stream_url.startswith('http://localhost:'):
                 streamlink_cmd = [
                     'streamlink',

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -205,7 +205,7 @@ class DownloadBase(ABC):
                 '-c',
                 'copy',
             ]
-            if use_streamlink:
+            if use_streamlink and not self.raw_stream_url.startswith('http://localhost:'):
                 streamlink_cmd = [
                     'streamlink',
                     '--stream-segment-threads', '3',

--- a/biliup/plugins/twitch.py
+++ b/biliup/plugins/twitch.py
@@ -112,8 +112,7 @@ class Twitch(DownloadBase, BatchCheck):
         if is_check:
             return True
 
-        # https://github.com/biliup/biliup/issues/991
-        if self.downloader == 'ffmpeg':
+        if self.downloader in ['streamlink', 'ffmpeg']:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.bind(('localhost', 0))
                 port = s.getsockname()[1]


### PR DESCRIPTION
回归下载器选择streamlink时的正常行为，否则其实twitch那两个streamlink的参数实际上是下载器在ffmpeg时候才能用到的，不过感觉这么写好丑……
另一个想法是给streamlink下载加个参数然后全局下载器命令接受这些参数作为输入，可能也更方便提供一些插件的自定义？
顺便看了下，nico也是给的streamlink参数然后流式输出到本地http，感觉会有跟twitch那边之前一样的问题？不过我跑半天nico直播也没跑起来一直403。