### PR TITLE
fix: stream-gears上传投稿参数错误

### DIFF
--- a/biliup/plugins/stream_gears.py
+++ b/biliup/plugins/stream_gears.py
@@ -76,25 +76,25 @@ class BiliWeb(UploadBase):
         if self.dtime:
             dtime = int(time.time() + self.dtime)
         stream_gears.upload(
-            file_list,
-            self.user_cookie,
-            self.data["format_title"][:80],
-            self.tid,
-            tag,
-            self.copyright,
-            source,
-            self.desc,
-            self.dynamic,
-            cover,
-            self.dolby,
-            self.hires,
-            self.no_reprint,
-            self.open_elec,
-            self.threads,
-            desc_v2,
-            dtime,
-            line,
-            self.extra_fields
+            video_path=file_list,
+            cookie_file=self.user_cookie,
+            title=self.data["format_title"][:80],
+            tid=self.tid,
+            tag=tag,
+            copyright=self.copyright,
+            source=source,
+            desc=self.desc,
+            dynamic=self.dynamic,
+            cover=cover,
+            dolby=self.dolby,
+            lossless_music=self.hires,
+            no_reprint=self.no_reprint,
+            open_elec=self.open_elec,
+            limit=self.threads,
+            desc_v2=desc_v2,
+            dtime=dtime,
+            line=line,
+            extra_fields=self.extra_fields
         )
         logger.info(f"上传成功: {self.principal}")
         return file_list


### PR DESCRIPTION
fix #1214, fix #1204, fix #1161
#1193 应该也是这个问题

steam_gears.upload新加入了topic_id参数，但biliup中没有，多个参数没有对应上。
这会导致用户手动上传投稿失败，日志如下：

```
2025-04-02 23:30:53,039 uploader.py[line:64](Pid:1 Tname:Thread-13 (biliup_uploader)) ERROR Uncaught exception:
Traceback (most recent call last):
  File "/biliup/biliup/uploader.py", line 62, in biliup_uploader
    return cls(index, data, **kwargs).upload(filelist)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/biliup/biliup/plugins/stream_gears.py", line 78, in upload
    stream_gears.upload(
TypeError: argument 'copyright': 'str' object cannot be interpreted as an integer
```
