### PR TITLE
fix(Plugins.Huya): Update HuYaUA

### DIFF
--- a/app/ui/plugins/huya.tsx
+++ b/app/ui/plugins/huya.tsx
@@ -120,8 +120,18 @@ const Huya: React.FC<Props> = props => {
         />
         <Form.Switch
           field="huya_mobile_api"
-          extraText="使用移动端API可以绕过 PCWEB 端对原画的时长限制"
-          label="虎牙使用移动端API（huya_mobile_api）"
+          extraText="移动端 API 请求直播间信息，可能解决部分直播分区 2 分钟分段问题"
+          label="使用移动端 API（huya_mobile_api）"
+          fieldStyle={{
+            alignSelf: 'stretch',
+            padding: 0,
+          }}
+        />
+        <Form.Switch
+          field="huya_use_wup"
+          extraText="使用 WUP 协议的请求头，可能解决部分直播分区 2 分钟分段问题"
+          label="使用 WUP 协议（huya_use_wup）"
+          initValue={entity?.hasOwnProperty('huya_use_wup') ? entity['huya_use_wup'] : true}
           fieldStyle={{
             alignSelf: 'stretch',
             padding: 0,

--- a/biliup/__init__.py
+++ b/biliup/__init__.py
@@ -2,7 +2,7 @@ import logging
 import platform
 import sys
 
-__version__ = "0.4.97"
+__version__ = "0.4.98"
 
 LOG_CONF = {
     'version': 1,

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -104,13 +104,16 @@ class DownloadBase(ABC):
         return True
 
     def download(self):
-        logger.info(f"{self.plugin_msg}: Start downloading {self.raw_stream_url}")
+        # print(f"{self.plugin_msg}: Plugin settings - {self.__dict__}")
+        logger.info(f"{self.plugin_msg}: Plugin settings - {self.__dict__}")
+        # logger.info(f"{self.plugin_msg}: Request headers - {self.fake_headers}")
+        logger.info(f"{self.plugin_msg}: Request url - {self.raw_stream_url}")
         # 调试使用边录边上传功能
         # self.downloader = 'sync-downloader'
         if self.is_download:
             if not shutil.which("ffmpeg"):
                 logger.error("未安装 FFMpeg 或不存在于 PATH 内")
-                logger.debug("Current user's PATH is:" + os.getenv("PATH"))
+                logger.info("Current user's PATH is:" + os.getenv("PATH"))
                 return False
             else:
                 return self.ffmpeg_segment_download()
@@ -119,7 +122,7 @@ class DownloadBase(ABC):
         if self.downloader != 'stream-gears':
             if not shutil.which("ffmpeg"):
                 logger.error("未安装 FFMpeg 或不存在于 PATH 内，本次下载使用 stream-gears")
-                logger.debug("Current user's PATH is:" + os.getenv("PATH"))
+                logger.info("Current user's PATH is:" + os.getenv("PATH"))
             else:
                 # 同步下载上传器
                 if self.downloader == 'sync-downloader':

--- a/biliup/plugins/huya.py
+++ b/biliup/plugins/huya.py
@@ -37,11 +37,12 @@ class Huya(DownloadBase):
         self.huya_cdn_fallback = config.get('huya_cdn_fallback', False)
         self.huya_mobile_api = config.get('huya_mobile_api', False)
         self.huya_codec = config.get('huya_codec', '264')
+        self.huya_use_wup = config.get('huya_use_wup', True)
 
     async def acheck_stream(self, is_check=False):
         # return False
-        # self.huya_mobile_api = False
-        # self.huya_imgplus = False
+        self.huya_mobile_api = False
+        self.huya_imgplus = True
         try:
             if not self.__room_id.isdigit():
                 client.headers.update(self.fake_headers)
@@ -70,15 +71,17 @@ class Huya(DownloadBase):
 
         # self.room_title = room_profile['room_title']
 
-        is_xingxiu = (room_profile['gid'] == 1663)
-        skip_query_build = (is_xingxiu or self.huya_mobile_api) and self.huya_imgplus
+        # is_xingxiu = (room_profile['gid'] == 1663)
+        gid_blacklist = [1663, ]
+        skip_query_build = self.huya_imgplus and (self.huya_mobile_api or room_profile['gid'] in gid_blacklist)
         stream_urls = self.build_stream_urls(room_profile['streams_info'], skip_query_build)
         cdn_list = list(stream_urls.keys())
         if not self.huya_cdn or self.huya_cdn not in cdn_list:
             self.huya_cdn = cdn_list[0]
 
         # Thx stream-rec
-        self.update_headers(self.fake_headers)
+        if self.huya_use_wup:
+            self.update_headers(self.fake_headers)
 
         try:
             self.raw_stream_url = self.add_ratio(

--- a/biliup/plugins/huya.py
+++ b/biliup/plugins/huya.py
@@ -40,9 +40,7 @@ class Huya(DownloadBase):
         self.huya_use_wup = config.get('huya_use_wup', True)
 
     async def acheck_stream(self, is_check=False):
-        # return False
-        self.huya_mobile_api = False
-        self.huya_imgplus = True
+
         try:
             if not self.__room_id.isdigit():
                 client.headers.update(self.fake_headers)
@@ -114,7 +112,7 @@ class Huya(DownloadBase):
             if not room_profile['live']:
                 logger.debug(f"{self.plugin_msg}: {room_profile['message']}")
                 return False
-            stream_urls = self.build_stream_urls(room_profile['streams_info'], is_xingxiu)
+            stream_urls = self.build_stream_urls(room_profile['streams_info'], skip_query_build)
 
         self.raw_stream_url = self.add_ratio(
             stream_urls[self.huya_cdn],


### PR DESCRIPTION
### 修复 PcWeb 部分主播以 string 储存 anchor_uid 导致的 ValueError
 - Fixes #1272
 - Fixes #1274 

### 更新 HuYaUA 为 huya_nftv 端，允许不使用此 User-Agent
 - Fixes #1288 

### 开启 mobile_api 且允许 imgplus 时，跳过构建 anticode
 - Fixes #1275 
 - Fixes #1290 