### PR TITLE
fix(Plugins.Huya): 修复当标题存在转义字符时正则匹配失败的问题

### DIFF
--- a/biliup/plugins/huya.py
+++ b/biliup/plugins/huya.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import random
 import time
+import html
 from urllib.parse import parse_qs, unquote
 from async_lru import alru_cache
 from typing import (
@@ -255,7 +256,7 @@ class Huya(DownloadBase):
                 f"{HUYA_MP_BASE_URL}/cache.php",
                 headers=self.fake_headers, params=params)
             resp.raise_for_status()
-            resp = json_loads(resp.text)
+            resp = json_loads(html.unescape(resp.text))
             if resp['status'] != 200:
                 raise Exception(f"{resp['message']}")
         else:
@@ -263,7 +264,7 @@ class Huya(DownloadBase):
                 f"{HUYA_WEB_BASE_URL}/{self.__room_id}",
                 headers=self.fake_headers)
             resp.raise_for_status()
-            resp = resp.text
+            resp = html.unescape(resp.text)
             _raise_for_room_block(resp)
         return self.extract_room_profile(resp)
 


### PR DESCRIPTION
当直播标题带有`&amp;`(&)等转义字符时，现阶段会提前结束正则匹配，导致无法检测状态。