### PR TITLE
也许修复了边录边传投稿标题不正确

### DIFF
--- a/biliup/plugins/bili_webup_sync.py
+++ b/biliup/plugins/bili_webup_sync.py
@@ -86,6 +86,8 @@ class BiliWebAsync(UploadBase):
 
         bili.login(self.persistence_path, self.user_cookie)
         videos.title = self.data["format_title"][:80]  # 稿件标题限制80字
+        # 保存初始稿件标题，供后续追加分 P 时复写使用
+        bili.origin_title = videos.title
         if self.credits:
             videos.desc_v2 = self.creditsToDesc_v2()
         else:
@@ -432,6 +434,9 @@ class BiliBili:
             videos = Data(**context_data)
 
         videos.append(video_part)  # 添加已经上传的视频
+        # 复写稿件标题，防止被分 P 标题覆盖
+        if getattr(self, 'origin_title', None):
+            videos.title = self.origin_title
         edit = False if videos.aid is None else True
         ret = self.submit(submit_api=submit_api, edit=edit, videos=videos)
         # logger.info(f"上传成功: {ret}")


### PR DESCRIPTION
在 BiliWebAsync.upload() 初始化后，缓存模板生成的标题到 origin_title 在 BiliBili.upload_stream() 每次提交（新增/编辑）前，将 videos.title 强制设为 origin_title，防止被后台覆盖