### PR TITLE
fix(Danmaku.bilibili): 修复B站弹幕连接异常

### DIFF
--- a/biliup/Danmaku/bilibili.py
+++ b/biliup/Danmaku/bilibili.py
@@ -8,6 +8,7 @@ import brotli
 
 from biliup.plugins import match1
 from biliup.plugins import random_user_agent
+from biliup.plugins import wbi
 
 logger = logging.getLogger('biliup')
 
@@ -44,7 +45,14 @@ class Bilibili:
                                    timeout=5) as resp:
                     room_json = await resp.json()
                     room_id = room_json['data']['room_id']
-            async with session.get(f"https://api.live.bilibili.com/xlive/web-room/v1/index/getDanmuInfo?type=0&id={room_id}",
+            # 2025-05-29 B站新风控需要WBI
+            params = {
+                'id': str(room_id),
+                'type': '0',
+                'web_location': '444.8'
+            }
+            wbi.sign(params)
+            async with session.get(f"https://api.live.bilibili.com/xlive/web-room/v1/index/getDanmuInfo",params=params,
                                    timeout=5) as resp:
                 danmu_info = await resp.json()
                 danmu_token = danmu_info['data']['token']


### PR DESCRIPTION
2025-05-27B站`api.live.bilibili.com/xlive/web-room/v1/index/getDanmuInfo`接口需要携带WBI信息, 简单修复了一下, 测试修改后可以正常录制B站弹幕, 可能需要review一下, 不太熟悉Python, 不知道wbi在设计的时候有没有考虑在plugin包之外使用.