### PR TITLE
fix: 回滚文件名编解码返回逻辑以修复直接出现 unicode 的问题

### DIFF
--- a/.vscode/setting.json
+++ b/.vscode/setting.json
@@ -1,6 +1,0 @@
-{
-    "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": "explicit"
-    }
-}

--- a/biliup/engine/download.py
+++ b/biliup/engine/download.py
@@ -372,7 +372,7 @@ class DownloadBase(ABC):
             end_time = time.localtime()
 
         self.download_cover(
-            time.strftime(self.gen_download_filename(), end_time if end_time else time.localtime()
+            time.strftime(self.gen_download_filename().encode("unicode-escape").decode(), end_time if end_time else time.localtime()
                           ).encode().decode("unicode-escape"))
         # 更新数据库中封面存储路径
         with SessionLocal() as db:
@@ -495,9 +495,9 @@ class DownloadBase(ABC):
                 if os.path.exists(f"{fmt_file_name}.{self.suffix}"):
                     file_time += 1
                 else:
-                    filename = fmt_file_name
-                    break
-        return filename.encode("unicode-escape").decode()
+                    return fmt_file_name
+        else:
+            return filename
 
     @staticmethod
     def download_file_rename(old_file_name, file_name):


### PR DESCRIPTION
解决因 https://github.com/biliup/biliup/commit/9c95762e78735127473f539576a9f83c1cf6338a 
导致的Windows下无法保存文件以及 https://github.com/biliup/biliup/issues/1320
和 https://github.com/biliup/biliup/issues/1324
中的BUG