### PR TITLE
更改Termux的wheel发布至Release

### DIFF
--- a/.github/workflows/Termux-publish.yml
+++ b/.github/workflows/Termux-publish.yml
@@ -1,0 +1,61 @@
+name: Build Termux Wheel to Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Build frontend
+        run: |
+          npm install
+          npm run build
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Set up Android NDK
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r26d
+      - name: Install dependencies and Android target
+        run: |
+          pip install maturin
+          rustup target add aarch64-linux-android
+      - name: Set up CPython interpreter for cross-compilation
+        run: |
+          BASE_URL="https://packages.termux.dev/apt/termux-main/pool/main/p/python"
+          FNAME=$(curl -s "$BASE_URL/" | grep -oE 'python_[0-9]+\.[0-9]+\.[0-9]+_aarch64\.deb' | { IFS= read -r line; echo "$line"; })
+          wget -nv "$BASE_URL/$FNAME"
+          mkdir python
+          dpkg-deb -x $FNAME python
+          cp -a python/data/data/com.termux/files/usr/lib/libpython* $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/24
+          sed -i 's/pyo3 = { version = "0.24.0", features = \[.*\] }/pyo3 = { version = "0.24.0" }/' crates/stream-gears/Cargo.toml
+          sed -i '/dependencies = \[/a\    "quickjs >= 1.19.4",' pyproject.toml
+      - name: Build wheel for aarch64 (Termux)
+        run: |
+          export NDK_BIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin
+          export CC_aarch64_linux_android=$NDK_BIN/aarch64-linux-android24-clang
+          export AR_aarch64_linux_android=$NDK_BIN/llvm-ar
+          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$NDK_BIN/aarch64-linux-android24-clang
+          export PYO3_CROSS_LIB_DIR=python/data/data/com.termux/files/usr/lib/
+          maturin build \
+            --release \
+            --strip \
+            --manylinux off \
+            --target aarch64-linux-android \
+            --out dist
+      - name: Upload wheel to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.whl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,56 +196,6 @@ jobs:
           name: wheels-macos-${{ matrix.platform.target }}
           path: dist
 
-  termux:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '20'
-      - name: Build frontend
-        run: |
-          npm install
-          npm run build
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - name: Set up Android NDK
-        uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r26d
-      - name: Install dependencies and Android target
-        run: |
-          pip install maturin
-          rustup target add aarch64-linux-android
-      - name: Set up CPython interpreter for cross-compilation
-        run: |
-          BASE_URL="https://packages.termux.dev/apt/termux-main/pool/main/p/python"
-          FNAME=$(curl -s "$BASE_URL/" | grep -oE 'python_[0-9]+\.[0-9]+\.[0-9]+_aarch64\.deb' | { IFS= read -r line; echo "$line"; })
-          wget -nv "$BASE_URL/$FNAME"
-          mkdir python
-          dpkg-deb -x $FNAME python
-          sed -i 's/pyo3 = { version = "0.24.0", features = \[.*\] }/pyo3 = { version = "0.24.0" }/' crates/stream-gears/Cargo.toml
-          cp -a python/data/data/com.termux/files/usr/lib/libpython* $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/24
-      - name: Build wheel for aarch64 (Termux)
-        run: |
-          export NDK_BIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin
-          export CC_aarch64_linux_android=$NDK_BIN/aarch64-linux-android24-clang
-          export AR_aarch64_linux_android=$NDK_BIN/llvm-ar
-          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$NDK_BIN/aarch64-linux-android24-clang
-          export PYO3_CROSS_LIB_DIR=python/data/data/com.termux/files/usr/lib/
-          maturin build \
-            --release \
-            --strip \
-            --manylinux off \
-            --target aarch64-linux-android \
-            --out dist
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-termux-aarch64
-          path: dist
-  
   sdist:
     runs-on: ubuntu-latest
     steps:
@@ -272,7 +222,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
-    needs: [linux, musllinux, windows, macos, termux, sdist]
+    needs: [linux, musllinux, windows, macos, sdist]
     permissions:
       # Use to sign the release artifacts
       id-token: write

--- a/README.md
+++ b/README.md
@@ -48,11 +48,7 @@
 4. 访问 WebUI：`http://your-ip:19159`
 
 ### Termux
-1. 仅为64位 Android 7.0+预编译wheel(本地编译见Wiki)
-2. 仅支持最新版 Python：`pkg install libxml2 libxslt getconf python -y`
-3. 安装：`pip3 install biliup`
-4. 启动：`biliup start`
-5. 访问 WebUI：`http://your-ip:19159`
+- 详见[Wiki](https://github.com/biliup/biliup/wiki/Termux-%E4%B8%AD%E4%BD%BF%E7%94%A8-biliup)
 
 
 ---


### PR DESCRIPTION
增加Termux使用教程链接
由于PyPI不支持Termux的platform tag，改为发布至Release