### PR TITLE
Fix template name encoding error

### DIFF
--- a/biliup/__init__.py
+++ b/biliup/__init__.py
@@ -21,7 +21,7 @@ LOG_CONF = {
     'handlers': {
         'console': {
             'level': logging.DEBUG,
-            'class': 'logging.StreamHandler',
+            'class': 'biliup.common.log.SafeStreamHandler',
             'stream': sys.stdout,
             'formatter': 'simple'
         },

--- a/biliup/__main__.py
+++ b/biliup/__main__.py
@@ -15,6 +15,17 @@ from biliup.common.log import DebugLevelFilter
 
 
 def arg_parser():
+    # 处理Windows系统的编码问题
+    import platform
+    if platform.system() == 'Windows':
+        import io
+        import sys
+        # 重新配置stdout和stderr以支持UTF-8
+        if hasattr(sys.stdout, 'buffer'):
+            sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace', line_buffering=True)
+        if hasattr(sys.stderr, 'buffer'):
+            sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8', errors='replace', line_buffering=True)
+
     daemon = Daemon('watch_process.pid', lambda: main(args))
     parser = argparse.ArgumentParser(description='Stream download and upload, not only for bilibili.')
     parser.add_argument('--version', action='version', version=f"v{__version__}")

--- a/biliup/engine/decorators.py
+++ b/biliup/engine/decorators.py
@@ -33,8 +33,9 @@ class Plugin:
         def decorator(cls):
             @functools.wraps(cls)
             def wrapper(*args, **kw):
-                print(f"args {args}")
-                print(f"kw {kw}")
+                # 移除可能导致编码问题的print语句
+                # print(f"args {args}")
+                # print(f"kw {kw}")
                 return cls(*args, **kw)
             Plugin.upload_plugins[platform] = wrapper
             return wrapper


### PR DESCRIPTION
Fix UnicodeEncodeError on Windows by improving console and log output encoding to support special characters in template names.