### PR TITLE
fix(upload): fix glitches in max_upload_limit

### DIFF
--- a/biliup/engine/upload.py
+++ b/biliup/engine/upload.py
@@ -32,16 +32,10 @@ class UploadBase:
         from biliup.handler import event_manager
         with NamedLock("file_upload_count"):
             file_upload_count = event_manager.context['file_upload_count']
-            for file_name in os.listdir('.'):
-                if file_name not in file_upload_count:
-                    file_upload_count[file_name] = 0
-            for file_name in list(file_upload_count):
-                if file_name not in os.listdir('.'):
-                    del file_upload_count[file_name]
             max = 0
             for item in filelist:
-                if file_upload_count[item.video] > max:
-                    max = file_upload_count[item.video]
+                current = file_upload_count.setdefault(item.video, 0)
+                max = current if current > max else max
                 file_upload_count[item.video] += 1
         return max
 


### PR DESCRIPTION
fix: 修复下播延迟检测期间文件名改动导致上传错误KeyError, 在延迟检测后重新获取上传文件以回归之前版本的行为
v1.0.1之前: 下播延迟检测结束 -> upload()内部会重新获取上传文件列表 -> 延迟检测期间改动过但符合主播命名规则文件可以被正常上传投稿(未restart的情况下投稿的title时间等信息正常保留)
v1.0.1加入上传重试次数限制后: 下播延迟检测结束 -> upload()前get_max_upload_count()检测文件上传次数(但未更新文件列表) -> 延迟检测期间的改动造成KeyError -> 上传错误 -> 再次等待下播延迟检测后重新上传 -> 因为文件名变动丢失投稿title时间等信息(即使在未restart的情况下)

refine: get_max_upload_count() 次数统计不再包含运行目录下无关的所有文件和目录