### PR TITLE
feat: add cid field to Video struct

### DIFF
--- a/crates/biliup/src/uploader/bilibili.rs
+++ b/crates/biliup/src/uploader/bilibili.rs
@@ -186,6 +186,8 @@ pub struct Video {
     pub title: Option<String>,
     pub filename: String,
     pub desc: String,
+    #[serde(skip)]
+    pub cid: usize,
 }
 
 impl Video {
@@ -194,6 +196,7 @@ impl Video {
             title: None,
             filename: filename.into(),
             desc: "".into(),
+            cid: 0,
         }
     }
 }

--- a/crates/biliup/src/uploader/line/upos.rs
+++ b/crates/biliup/src/uploader/line/upos.rs
@@ -185,6 +185,7 @@ impl Upos {
                 .unwrap()
                 .into(),
             desc: "".into(),
+            cid: self.bucket.biz_id,
         })
     }
 }


### PR DESCRIPTION
## Summary
- Add cid field to Video struct with #[serde(skip)] annotation
- Initialize cid to 0 in Video::new() constructor  
- Set cid to self.bucket.biz_id in Upos::complete() method

## Description
This PR adds a cid (content ID) field to the Video struct to track the business ID associated with uploaded videos. The field is excluded from serialization using #[serde(skip)] and is properly initialized in both the constructor and during upload completion.
