### PR TITLE
fix: 修复 shellexpand::tilde 类型错误并优化 Nix flake 配置

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "serde_yaml",
+ "shellexpand",
  "sqlx",
  "struct-patch",
  "tempfile",
@@ -946,6 +947,27 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2254,6 +2276,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ormlite"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2876,6 +2904,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,6 +3364,15 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "shlex"

--- a/crates/biliup-cli/flake.lock
+++ b/crates/biliup-cli/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764124769,
-        "narHash": "sha256-vcoOEy3i8AGJi3Y2C48hrf6CuL2h8W1gLe1gNt72Kxg=",
+        "lastModified": 1764297505,
+        "narHash": "sha256-qrLpVu2/hA9Cu6IovMEsgh9YRyvmmWS+bSx7C1JGChA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5da8c00313b4434f00aed6b4c94cd3b207bafdc5",
+        "rev": "9623580f8ce09ec444b9aca107566ec5db110e62",
         "type": "github"
       },
       "original": {

--- a/crates/biliup-cli/flake.nix
+++ b/crates/biliup-cli/flake.nix
@@ -31,6 +31,12 @@
           cargoToml = ./Cargo.toml;
         };
 
+        # Skip frontend build - create empty placeholder
+        frontend = pkgs.runCommand "biliup-frontend-empty" {} ''
+          mkdir -p $out
+          echo '<!DOCTYPE html><html><body>Frontend disabled</body></html>' > $out/index.html
+        '';
+
         # Common arguments for crane
         commonArgs = {
           src = craneLib.cleanCargoSource ../..;
@@ -49,6 +55,12 @@
             pkgs.pkg-config
             pkgs.python3
           ];
+
+          # Make frontend build output available
+          preBuild = ''
+            mkdir -p out
+            cp -r ${frontend}/* out/
+          '';
         };
 
         # Build *just* the cargo dependencies, so we can reuse

--- a/crates/biliup-cli/src/cli.rs
+++ b/crates/biliup-cli/src/cli.rs
@@ -8,9 +8,8 @@ use std::path::PathBuf;
 /// 扩展路径中的 ~ 为用户主目录
 pub fn expand_path(path: PathBuf) -> PathBuf {
     if let Some(path_str) = path.to_str() {
-        if let Ok(expanded) = shellexpand::tilde(path_str) {
-            return PathBuf::from(expanded.as_ref());
-        }
+        let expanded = shellexpand::tilde(path_str);
+        return PathBuf::from(expanded.as_ref());
     }
     path
 }

--- a/crates/biliup-cli/src/uploader.rs
+++ b/crates/biliup-cli/src/uploader.rs
@@ -258,11 +258,8 @@ async fn login_by_cookies(user_cookie: PathBuf, proxy: Option<&str>) -> AppResul
 pub async fn cover_up(studio: &mut Studio, bili: &BiliBili) -> AppResult<()> {
     if !studio.cover.is_empty() {
         // 扩展路径中的 ~ 为用户主目录
-        let cover_path = if let Ok(expanded) = shellexpand::tilde(&studio.cover) {
-            PathBuf::from(expanded.as_ref())
-        } else {
-            PathBuf::from(&studio.cover)
-        };
+        let expanded = shellexpand::tilde(&studio.cover);
+        let cover_path = PathBuf::from(expanded.as_ref());
 
         let url = bili
             .cover_up(


### PR DESCRIPTION
## 问题描述

在使用 `shellexpand::tilde()` 时,代码错误地将其作为 `Result` 类型处理,但实际上该函数返回 `Cow<'_, str>` 类型。

## 修复内容

### 1. 修复 shellexpand::tilde 类型错误
- **问题**: `shellexpand::tilde()` 返回 `Cow<'_, str>`,不是 `Result`
- **修复**: 
  - `crates/biliup-cli/src/cli.rs:10`: 移除错误的 `Result` 模式匹配,直接使用返回值
  - `crates/biliup-cli/src/uploader.rs`: 同样修复类型处理

### 2. 优化 Nix flake 配置
- **问题**: 原 flake.nix 中前端构建使用 `buildNpmPackage`,需要下载大量 npm 依赖,在某些网络环境下构建会卡住
- **优化**: 
  - 将前端构建替换为轻量级占位符,跳过 npm 依赖下载
  - 减少构建时间和网络依赖
  - 命令行用户可通过 `biliup login` 的 6 种登录方式使用(扫码/短信/浏览器/Cookie 等),无需 Web 前端

## 相关 PR

修复了 #1550 中引入的类型错误