### PR TITLE
feat: upload_by_config 支持通过 Web 提交视频配置

### DIFF
--- a/crates/biliup-cli/src/uploader.rs
+++ b/crates/biliup-cli/src/uploader.rs
@@ -201,6 +201,10 @@ pub async fn upload_by_config(
                 .submit_by_bcut_android(&studio, proxy)
                 .await
                 .change_context_lazy(|| AppError::Unknown)?,
+            SubmitOption::Web => bilibili
+                .submit_by_web(&studio, proxy)
+                .await
+                .change_context_lazy(|| AppError::Unknown)?,
             _ => bilibili
                 .submit_by_app(&studio, proxy)
                 .await


### PR DESCRIPTION
submit_by_web 没有支持给 upload_by_config，补一下