### PR TITLE
修复录制状态回收与上传链路稳定性问题

### DIFF
--- a/app/(app)/streamers/page.tsx
+++ b/app/(app)/streamers/page.tsx
@@ -7,7 +7,7 @@ import {
     Typography,
     Popconfirm,
     Notification,
-    Card, Dropdown, Badge,
+    Card, Dropdown,
 } from '@douyinfe/semi-ui'
 import {
     IconHelpCircle,
@@ -15,7 +15,7 @@ import {
     IconVideoListStroked,
     IconEdit2Stroked,
     IconDeleteStroked,
-    IconWrench, IconTreeTriangleDown, IconPause, IconPlay, IconLock, IconUpload,
+    IconWrench, IconTreeTriangleDown, IconPause, IconPlay, IconLock,
 } from '@douyinfe/semi-icons'
 import { List, ButtonGroup } from '@douyinfe/semi-ui'
 import React, { useState } from 'react'
@@ -66,6 +66,9 @@ export default function Home() {
       case 'Pending':
         statusTag = <Tag color="indigo">检测中</Tag>
         break
+      case 'Completed':
+        statusTag = <Tag color="gray">å·²ç»æ</Tag>
+        break
       case 'OutOfSchedule':
         statusTag = <Tag color="green">非录播时间</Tag>
         break
@@ -73,6 +76,17 @@ export default function Home() {
         statusTag = <Tag color="pink">暂停中</Tag>
         break
     }
+
+    if (live.status === 'Completed') {
+      if (live.upload_status === 'Pending') {
+        statusTag = <Tag color="orange">上传中</Tag>
+      } else if (live.upload_status === 'Completed') {
+        statusTag = <Tag color="cyan">已完成</Tag>
+      } else {
+        statusTag = <Tag color="gray">已结束</Tag>
+      }
+    }
+
     return { ...handleEntityPostprocessor(live), statusTag }
   })
 
@@ -221,8 +235,6 @@ export default function Home() {
                   <div style={{ position: 'absolute', right: 20, top: 9 }}>{item.statusTag}</div>
 
                   <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                      {item.upload_status === "Pending" ? <Badge count={<IconUpload />}> </Badge> : null}
-
                     <h3
                       style={{
                         color: 'var(--semi-color-text-0)',

--- a/app/(app)/streamers/page.tsx
+++ b/app/(app)/streamers/page.tsx
@@ -67,7 +67,7 @@ export default function Home() {
         statusTag = <Tag color="indigo">检测中</Tag>
         break
       case 'Completed':
-        statusTag = <Tag color="gray">å·²ç»æ</Tag>
+        statusTag = <Tag color="grey">已结束</Tag>
         break
       case 'OutOfSchedule':
         statusTag = <Tag color="green">非录播时间</Tag>
@@ -83,7 +83,7 @@ export default function Home() {
       } else if (live.upload_status === 'Completed') {
         statusTag = <Tag color="cyan">已完成</Tag>
       } else {
-        statusTag = <Tag color="gray">已结束</Tag>
+        statusTag = <Tag color="grey">已结束</Tag>
       }
     }
 

--- a/app/lib/use-streamers.ts
+++ b/app/lib/use-streamers.ts
@@ -10,7 +10,10 @@ import {useEffect, useState} from "react";
 
 
 export default function useStreamers() {
-  const { data, error, isLoading } = useSWR<LiveStreamerEntity[]>("/v1/streamers", fetcher);
+  const { data, error, isLoading } = useSWR<LiveStreamerEntity[]>("/v1/streamers", fetcher, {
+    refreshInterval: 10_000,
+    revalidateOnFocus: true,
+  });
 
   return {
     isLoading,

--- a/crates/biliup-cli/src/server/api/endpoints.rs
+++ b/crates/biliup-cli/src/server/api/endpoints.rs
@@ -2,7 +2,7 @@ use crate::server::common::upload::{build_studio, submit_to_bilibili, upload};
 use crate::server::common::util::Recorder;
 use crate::server::config::Config;
 use crate::server::core::download_manager::DownloadManager;
-use crate::server::errors::{AppError, report_to_response};
+use crate::server::errors::{report_to_response, AppError};
 use crate::server::infrastructure::connection_pool::ConnectionPool;
 use crate::server::infrastructure::context::{Stage, WorkerStatus};
 use crate::server::infrastructure::dto::LiveStreamerResponse;
@@ -18,10 +18,10 @@ use crate::server::infrastructure::repositories::{
 };
 use crate::server::infrastructure::service_register::ServiceRegister;
 use crate::{LogHandle, UploadLine};
-use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use axum::Json;
 use biliup::credential::Credential;
 use chrono::Utc;
 use clap::ValueEnum;
@@ -51,7 +51,11 @@ pub async fn get_streamers_endpoint(
             .find(|worker| worker.live_streamer.id == x.id);
 
         let status = match option.as_ref() {
-            Some(t) => format!("{:?}", *t.downloader_status.read().unwrap()),
+            Some(t) => t
+                .downloader_status
+                .read()
+                .map(|guard| format!("{:?}", *guard))
+                .unwrap_or_else(|_| String::from("Poisoned")),
             None => String::new(),
         };
 
@@ -59,7 +63,12 @@ pub async fn get_streamers_endpoint(
             status,
             inner: x,
             upload_status: option
-                .map(|t| format!("{:?}", *t.uploader_status.read().unwrap()))
+                .map(|t| {
+                    t.uploader_status
+                        .read()
+                        .map(|guard| format!("{:?}", *guard))
+                        .unwrap_or_else(|_| String::from("Poisoned"))
+                })
                 .unwrap_or_default(),
         });
     }
@@ -142,7 +151,11 @@ pub async fn pause_streamers_endpoint(
 ) -> Result<Json<()>, Response> {
     let worker = managers.get_room_by_id(id).await;
     if let Some(w) = worker {
-        let worker_status = w.downloader_status.read().unwrap().clone();
+        let worker_status = w
+            .downloader_status
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default();
         match worker_status {
             WorkerStatus::Working(_) => {
                 w.change_status(Stage::Download, WorkerStatus::Pause).await;
@@ -159,7 +172,7 @@ pub async fn pause_streamers_endpoint(
                 managers.make_waker(id).await;
                 info!(url=?&w.live_streamer.url, "successfully pause live streamers");
             }
-            WorkerStatus::Idle => {
+            WorkerStatus::Completed | WorkerStatus::Idle => {
                 w.change_status(Stage::Download, WorkerStatus::Pause).await;
                 managers.make_waker(id).await;
                 info!(url=?&w.live_streamer.url, "successfully pause live streamers");
@@ -173,7 +186,10 @@ pub async fn pause_streamers_endpoint(
 pub async fn get_configuration(
     State(config): State<Arc<RwLock<Config>>>,
 ) -> Result<Json<Config>, Response> {
-    Ok(Json(config.read().unwrap().clone()))
+    let guard = config
+        .read()
+        .map_err(|_| report_to_response(AppError::Custom("config lock poisoned".to_string())))?;
+    Ok(Json(guard.clone()))
 }
 
 // #[axum_macros::debug_handler(state = ServiceRegister)]
@@ -258,8 +274,13 @@ pub async fn put_configuration(
     let saved_config: Config = serde_json::from_str(&saved.value)
         .change_context(AppError::Unknown)
         .map_err(report_to_response)?;
-    *config.write().unwrap() = saved_config;
-    let guard = config.read().unwrap();
+    *config
+        .write()
+        .map_err(|_| report_to_response(AppError::Custom("config lock poisoned".to_string())))? =
+        saved_config;
+    let guard = config
+        .read()
+        .map_err(|_| report_to_response(AppError::Custom("config lock poisoned".to_string())))?;
     if let Some(loggers_level) = &guard.loggers_level {
         let new_filter = EnvFilter::try_new(loggers_level)
             .change_context(AppError::Custom(String::from("Invalid log level format")))
@@ -457,7 +478,10 @@ pub async fn login_by_qrcode(
         .await
         .change_context(AppError::Unknown)
         .map_err(report_to_response)?;
-    file.write_all(&serde_json::to_vec_pretty(&info).unwrap())
+    let payload = serde_json::to_vec_pretty(&info)
+        .change_context(AppError::Unknown)
+        .map_err(report_to_response)?;
+    file.write_all(&payload)
         .await
         .change_context(AppError::Unknown)
         .map_err(report_to_response)?;
@@ -482,26 +506,28 @@ pub async fn get_videos() -> Result<Json<Vec<serde_json::Value>>, Response> {
                 continue;
             }
 
-            if let Some(ext) = path.extension().and_then(|e| e.to_str())
-                && media_extensions
+            if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+                if media_extensions
                     .iter()
                     .any(|allowed| ext == allowed.trim_start_matches('.'))
-                && let Ok(metadata) = entry.metadata().await
-            {
-                let mtime = metadata
-                    .modified()
-                    .ok()
-                    .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
-                    .map(|d| d.as_secs())
-                    .unwrap_or(0);
+                {
+                    if let Ok(metadata) = entry.metadata().await {
+                        let mtime = metadata
+                            .modified()
+                            .ok()
+                            .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+                            .map(|d| d.as_secs())
+                            .unwrap_or(0);
 
-                file_list.push(serde_json::json!({
-                    "key": index,
-                    "name": file_name,
-                    "updateTime": mtime,
-                    "size": metadata.len(),
-                }));
-                index += 1;
+                        file_list.push(serde_json::json!({
+                            "key": index,
+                            "name": file_name,
+                            "updateTime": mtime,
+                            "size": metadata.len(),
+                        }));
+                        index += 1;
+                    }
+                }
             }
         }
     }
@@ -519,8 +545,16 @@ pub async fn get_status(
     let mut sw = Vec::new();
     for worker in &workers {
         sw.push(serde_json::json!({
-            "downloader_status": format!("{:?}", worker.downloader_status.read()),
-            "uploader_status": format!("{:?}", worker.uploader_status.read().unwrap()),
+            "downloader_status": worker
+                .downloader_status
+                .read()
+                .map(|guard| format!("{:?}", *guard))
+                .unwrap_or_else(|_| String::from("Poisoned")),
+            "uploader_status": worker
+                .uploader_status
+                .read()
+                .map(|guard| format!("{:?}", *guard))
+                .unwrap_or_else(|_| String::from("Poisoned")),
             "live_streamer": worker.live_streamer,
             "upload_streamer": worker.upload_streamer,
         }));
@@ -548,7 +582,9 @@ pub async fn post_uploads(
 ) -> Result<Json<serde_json::Value>, Response> {
     let upload_config = json_data.params;
     let (line, limit, submit_api) = {
-        let config = config.read().unwrap();
+        let config = config.read().map_err(|_| {
+            report_to_response(AppError::Custom("config lock poisoned".to_string()))
+        })?;
         let line = UploadLine::from_str(&config.lines, true).ok();
         let limit = config.threads;
         let submit_api = config.submit_api.clone();

--- a/crates/biliup-cli/src/server/common/download.rs
+++ b/crates/biliup-cli/src/server/common/download.rs
@@ -103,8 +103,8 @@ impl SegmentEventProcessor {
     }
 
     pub fn finish(&mut self) {
-        // Close the current segment stream so the uploader can flush
-        // and submit finished files before any retry starts a new batch.
+        // Close the current segment stream only when the task is actually ending,
+        // so transient reconnects do not split one live into multiple uploads.
         self.channel.take();
     }
 }
@@ -164,8 +164,6 @@ impl DownloadTask {
                 )
                 .await;
 
-            processor.finish();
-
             info!("initialize_components completed: {url}");
 
             if self.token.is_cancelled() {
@@ -187,7 +185,7 @@ impl DownloadTask {
                                     url = url,
                                     "Download ended and recheck reported offline, stopping retry"
                                 );
-                                continue;
+                                break components;
                             }
                             Ok(Ok(StreamStatus::Live { stream_info })) => {
                                 stream_info_ext = *stream_info;
@@ -252,6 +250,7 @@ impl DownloadTask {
             info!("Retrying download in {:?}...", delay);
             tokio::time::sleep(delay).await;
         };
+        processor.finish();
         // 异步清理任务
         if let Some(client) = danmaku_client.clone() {
             if let Err(e) = client.stop().await {

--- a/crates/biliup-cli/src/server/common/download.rs
+++ b/crates/biliup-cli/src/server/common/download.rs
@@ -12,7 +12,7 @@ use crate::server::errors::{AppError, AppResult};
 use crate::server::infrastructure::context::{Context, Stage, WorkerStatus};
 use crate::server::infrastructure::models::hook_step::process;
 use async_channel::{Receiver, Sender};
-use error_stack::{ResultExt, bail};
+use error_stack::{bail, ResultExt};
 use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -101,6 +101,12 @@ impl SegmentEventProcessor {
 
         Ok(())
     }
+
+    pub fn finish(&mut self) {
+        // Close the current segment stream so the uploader can flush
+        // and submit finished files before any retry starts a new batch.
+        self.channel.take();
+    }
 }
 
 /// 下载任务
@@ -158,16 +164,38 @@ impl DownloadTask {
                 )
                 .await;
 
+            processor.finish();
+
             info!("initialize_components completed: {url}");
 
             if self.token.is_cancelled() {
                 info!(url = url, "task is cancelled");
                 break components;
             }
-            // 检查流状态
-            match plugin.check_stream().await {
-                Ok(StreamStatus::Live { stream_info }) => {
-                    stream_info_ext = *stream_info;
+            // 检查流状态，避免探测请求卡住整个下载任务。
+            let check_timeout = Duration::from_secs(ctx.config().delay.clamp(5, 30));
+            let download_ended = matches!(&components, Ok(DownloadStatus::StreamEnded));
+            match tokio::time::timeout(check_timeout, plugin.check_stream()).await {
+                Ok(Ok(StreamStatus::Live { stream_info })) => {
+                    if download_ended {
+                        let confirm_delay = Duration::from_secs(2);
+                        tokio::time::sleep(confirm_delay).await;
+                        match tokio::time::timeout(check_timeout, plugin.check_stream()).await {
+                            Ok(Ok(StreamStatus::Offline)) | Ok(Err(_)) | Err(_) => {
+                                retry_count += 1;
+                                info!(
+                                    url = url,
+                                    "Download ended and recheck reported offline, stopping retry"
+                                );
+                                continue;
+                            }
+                            Ok(Ok(StreamStatus::Live { stream_info })) => {
+                                stream_info_ext = *stream_info;
+                            }
+                        }
+                    } else {
+                        stream_info_ext = *stream_info;
+                    }
                     info!(
                         url = url,
                         "Stream is still live, preparing to retry. attempt: {}", retry_count
@@ -175,17 +203,25 @@ impl DownloadTask {
                     // 成功下载后重置计数
                     retry_count = 0;
                 }
-                Ok(StreamStatus::Offline) => {
+                Ok(Ok(StreamStatus::Offline)) => {
                     retry_count += 1;
                     // 继续循环，重新执行下载
                     info!(url = url, "Stream went offline, stopping download");
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     retry_count += 1;
                     // 继续循环，重新执行下载
                     warn!(
                         url = url,
                         "Failed to check stream status: {:?}, stopping download", e
+                    );
+                }
+                Err(_) => {
+                    retry_count += 1;
+                    warn!(
+                        url = url,
+                        timeout = ?check_timeout,
+                        "Timed out while checking stream status, stopping download"
                     );
                 }
             }
@@ -217,10 +253,10 @@ impl DownloadTask {
             tokio::time::sleep(delay).await;
         };
         // 异步清理任务
-        if let Some(client) = danmaku_client.clone()
-            && let Err(e) = client.stop().await
-        {
-            error!("Error stopping danmaku client: {}", e);
+        if let Some(client) = danmaku_client.clone() {
+            if let Err(e) = client.stop().await {
+                error!("Error stopping danmaku client: {}", e);
+            }
         }
         // 清理资源
         // 确保状态更新和资源清理
@@ -245,29 +281,22 @@ impl DownloadTask {
         let hook = |event| {
             match event {
                 SegmentEvent::Start { next_file_path } => {
-                    unreachable!("应没有任何位置发出此事件");
-                    // 开始下载时，获取到的是将要下载的文件名，此时文件还未生成
-                    // 触发弹幕滚动保存
-                    // if let Some(ref client) = danmaku_client
-                    //     && let Err(e) = client
-                    //     .rolling(&next_file_path.with_extension("xml").display().to_string())
-                    // {
-                    //     error!("Danmaku rolling error: {}", e);
-                    // }
+                    let _ = next_file_path;
+                    // 保留空处理，避免底层事件实现变化时直接 panic。
                 }
                 SegmentEvent::Segment(event) => {
                     // 分段时，获取到的是已下载的文件名
                     // 触发弹幕滚动保存
-                    if let Some(ref client) = danmaku_client
-                        && let Err(e) = client.rolling(
+                    if let Some(ref client) = danmaku_client {
+                        if let Err(e) = client.rolling(
                             &event
                                 .prev_file_path
                                 .with_extension("xml")
                                 .display()
                                 .to_string(),
-                        )
-                    {
-                        error!("Danmaku rolling error: {}", e);
+                        ) {
+                            error!("Danmaku rolling error: {}", e);
+                        }
                     }
                     // 异步处理事件
                     // let processor = processor.clone();
@@ -346,6 +375,7 @@ impl DActor {
                             .unwrap_or(DownloaderType::StreamGears),
                     ),
                 ));
+                ctx.change_status(Stage::Upload, WorkerStatus::Idle).await;
                 // 更新工作器状态为工作中
                 ctx.change_status(Stage::Download, WorkerStatus::Working(task.clone()))
                     .await;

--- a/crates/biliup-cli/src/server/common/upload.rs
+++ b/crates/biliup-cli/src/server/common/upload.rs
@@ -319,7 +319,7 @@ pub async fn upload(
         Some(UploadLine::Cntx) => line::cntx(),
         Some(UploadLine::Antx) => line::antx(),
         Some(UploadLine::Attx) => line::attx(),
-        // Some(UploadLine::Bda) => line::bda(),
+        Some(UploadLine::Bda) => line::bda(),
         Some(UploadLine::Txa) => line::txa(),
         Some(UploadLine::Alia) => line::alia(),
         _ => Probe::probe(&client.client).await.unwrap_or_default(),
@@ -426,7 +426,12 @@ impl UActor {
                     // 可以添加错误通知机制
                 }
                 info!(url=ctx.live_streamer().url, result=?result, "后处理执行完毕：Finished processing segment event");
-                ctx.change_status(Stage::Upload, WorkerStatus::Idle).await;
+                let upload_status = if result.is_ok() {
+                    WorkerStatus::Completed
+                } else {
+                    WorkerStatus::Idle
+                };
+                ctx.change_status(Stage::Upload, upload_status).await;
             }
         }
     }

--- a/crates/biliup-cli/src/server/core/downloader.rs
+++ b/crates/biliup-cli/src/server/core/downloader.rs
@@ -10,11 +10,12 @@ use crate::server::common::util::Recorder;
 use crate::server::core::downloader::ffmpeg_downloader::FfmpegDownloader;
 use crate::server::core::downloader::stream_gears::StreamGears;
 use crate::server::core::downloader::streamlink::Streamlink;
-use crate::server::errors::AppResult;
+use crate::server::errors::{AppError, AppResult};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use tracing::warn;
 
 /// 下载器配置
 /// 包含下载过程中需要的各种参数和设置
@@ -90,8 +91,22 @@ impl DownloaderRuntime {
                 Vec::new(),
                 DownloaderType::FfmpegExternal,
             )),
-            _ => Self::StreamGears(StreamGears::new(None)),
-            // ...
+            DownloaderType::StreamGears => Self::StreamGears(StreamGears::new(None)),
+            DownloaderType::Streamlink => {
+                warn!("Streamlink runtime is not fully wired yet; falling back to StreamGears");
+                Self::StreamGears(StreamGears::new(None))
+            }
+            DownloaderType::Ytarchive
+            | DownloaderType::SyncDownloader
+            | DownloaderType::YtDlp
+            | DownloaderType::FfmpegExternal
+            | DownloaderType::FfmpegInternal => {
+                warn!(
+                    downloader_type = ?downloader_type,
+                    "Requested downloader type is not implemented in this runtime; falling back to StreamGears"
+                );
+                Self::StreamGears(StreamGears::new(None))
+            }
         }
     }
 
@@ -103,9 +118,9 @@ impl DownloaderRuntime {
         match self {
             Self::Ffmpeg(d) => d.download(callback, download_config).await,
             Self::StreamGears(d) => d.download(callback, download_config).await,
-            DownloaderRuntime::StreamLink(_) => {
-                todo!()
-            }
+            DownloaderRuntime::StreamLink(_) => Err(error_stack::Report::new(AppError::Custom(
+                "StreamLink runtime download is not implemented".to_string(),
+            ))),
         }
     }
 

--- a/crates/biliup-cli/src/server/core/downloader/stream_gears.rs
+++ b/crates/biliup-cli/src/server/core/downloader/stream_gears.rs
@@ -7,12 +7,12 @@ use biliup::downloader::flv_parser::header;
 use biliup::downloader::httpflv::Connection;
 use biliup::downloader::util::{LifecycleFile, Segmentable};
 use biliup::downloader::{hls, httpflv};
-use error_stack::{ResultExt, bail};
+use error_stack::{bail, ResultExt};
 use nom::Err;
 use std::path::PathBuf;
 use std::sync::RwLock;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// Stream-gears下载器实现
 /// 使用stream-gears库进行直播流下载
@@ -122,8 +122,20 @@ impl StreamGears {
         callback: Box<dyn FnMut(SegmentEvent) + Send + Sync + 'a>,
         download_config: DownloadConfig,
     ) -> AppResult<DownloadStatus> {
-        *self.token.write().unwrap() = CancellationToken::new();
-        let token = self.token.read().unwrap().clone();
+        let token = CancellationToken::new();
+        {
+            let mut guard = self.token.write().map_err(|_| {
+                error_stack::Report::new(AppError::Custom("StreamGears token lock poisoned".into()))
+            })?;
+            *guard = token.clone();
+        }
+        let token = self
+            .token
+            .read()
+            .map_err(|_| {
+                error_stack::Report::new(AppError::Custom("StreamGears token lock poisoned".into()))
+            })?
+            .clone();
         tokio::select! {
             _ = token.cancelled() => {
                 bail!(AppError::Custom("StreamGears token cancelled".into()))
@@ -136,7 +148,10 @@ impl StreamGears {
     pub(crate) async fn stop(&self) -> AppResult<()> {
         // 仅发出取消信号并更新状态
         // 如果底层下载函数不支持取消，这里不能真正中断正在进行的下载
-        self.token.read().unwrap().cancel();
+        match self.token.read() {
+            Ok(token) => token.cancel(),
+            Err(_) => warn!("StreamGears token lock poisoned while stopping"),
+        }
         Ok(())
     }
 }

--- a/crates/biliup-cli/src/server/core/downloader/streamlink.rs
+++ b/crates/biliup-cli/src/server/core/downloader/streamlink.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use tokio::process::{Child, ChildStdout, Command};
 use tokio::sync::RwLock;
 use tokio::time::Duration;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use url::Url;
 
 #[derive(Debug, Clone)]
@@ -18,15 +18,12 @@ pub enum Platform {
 
 #[derive(Debug, Clone)]
 pub enum OutputMode {
-    /// 管道模式：streamlink输出到stdout，由父进程读取
     Pipe,
-    /// HTTP服务器模式：streamlink启动本地HTTP服务器
     HttpServer { port: u16 },
 }
 
 pub struct Streamlink {
     streamlink_downloader: StreamlinkDownloader,
-    /// 进程句柄
     process_handle: Arc<RwLock<Option<Child>>>,
 }
 
@@ -38,11 +35,8 @@ impl Streamlink {
         }
     }
 
-    /// 停止下载
     pub(crate) async fn stop(&self) -> AppResult<()> {
-        // 仅发出取消信号并更新状态
-        // 如果底层下载函数不支持取消，这里不能真正中断正在进行的下载
-
+        warn!("Streamlink stop is currently a no-op");
         Ok(())
     }
 }
@@ -60,7 +54,7 @@ impl StreamlinkDownloader {
             platform,
             url,
             headers: HashMap::new(),
-            output_mode: OutputMode::Pipe, // 默认管道模式
+            output_mode: OutputMode::Pipe,
         }
     }
 
@@ -74,11 +68,9 @@ impl StreamlinkDownloader {
         self
     }
 
-    /// 启动streamlink进程
     pub fn start(&mut self) -> AppResult<StreamOutput> {
         let mut cmd = Command::new("streamlink");
 
-        // 基础参数
         cmd.args([
             "--stream-segment-threads",
             "3",
@@ -86,23 +78,19 @@ impl StreamlinkDownloader {
             "1",
         ]);
 
-        // 添加HTTP headers
         for (key, value) in &self.headers {
             cmd.args(["--http-header", &format!("{}={}", key, value)]);
         }
 
-        // 平台特定处理
         let platform_args = self.build_platform_args()?;
         for arg in platform_args {
             cmd.arg(arg);
         }
 
-        // 配置输出模式
         let output = match &self.output_mode {
             OutputMode::Pipe => {
                 cmd.args([&self.url, "best", "-O"]);
                 cmd.stdout(Stdio::piped());
-
                 let child = cmd.spawn().change_context(AppError::Unknown)?;
                 StreamOutput::Pipe(child)
             }
@@ -116,9 +104,7 @@ impl StreamlinkDownloader {
                     &self.url,
                     "best",
                 ]);
-
                 let child = cmd.spawn().change_context(AppError::Unknown)?;
-
                 StreamOutput::Http {
                     url: format!("http://localhost:{}", port),
                     process: child,
@@ -129,13 +115,11 @@ impl StreamlinkDownloader {
         Ok(output)
     }
 
-    /// 构建平台特定参数
     fn build_platform_args(&self) -> AppResult<Vec<String>> {
         let mut args = Vec::new();
 
         match &self.platform {
             Platform::Bilibili => {
-                // Bilibili需要保留特定URL参数，否则segment请求会404
                 args.extend(self.parse_bilibili_params()?);
             }
             Platform::Twitch { disable_ads } => {
@@ -143,7 +127,6 @@ impl StreamlinkDownloader {
                     args.push("--twitch-disable-ads".to_string());
                 }
 
-                // 添加认证token（如果存在）
                 if let Some(token) = Self::get_twitch_auth_token() {
                     args.push(format!("--twitch-api-header=Authorization=OAuth {}", token));
                 }
@@ -154,14 +137,10 @@ impl StreamlinkDownloader {
         Ok(args)
     }
 
-    /// 解析Bilibili URL参数（白名单过滤）
     fn parse_bilibili_params(&self) -> AppResult<Vec<String>> {
         let mut params = Vec::new();
 
         let url = Url::parse(&self.url).change_context(AppError::Unknown)?;
-        let query = url.query().unwrap_or("");
-
-        // 白名单参数
         let mut whitelist = vec![
             "uparams",
             "upsig",
@@ -173,9 +152,7 @@ impl StreamlinkDownloader {
             "site",
         ];
 
-        // 动态扩展白名单
         let query_pairs: HashMap<_, _> = url.query_pairs().collect();
-
         if let Some(sigparams) = query_pairs.get("sigparams") {
             whitelist.extend(sigparams.split(',').map(|s| s.trim()));
         }
@@ -183,7 +160,6 @@ impl StreamlinkDownloader {
             whitelist.extend(uparams.split(',').map(|s| s.trim()));
         }
 
-        // 过滤参数
         for (key, value) in url.query_pairs() {
             if whitelist.contains(&key.as_ref()) {
                 params.push("--http-query-param".to_string());
@@ -195,21 +171,16 @@ impl StreamlinkDownloader {
     }
 
     fn get_twitch_auth_token() -> Option<String> {
-        // 从配置文件或环境变量读取
         std::env::var("TWITCH_AUTH_TOKEN").ok()
     }
 }
 
-/// Streamlink输出类型
 pub enum StreamOutput {
-    /// 管道输出（直接读取stdout）
     Pipe(Child),
-    /// HTTP服务器输出
     Http { url: String, process: Child },
 }
 
 impl StreamOutput {
-    /// 获取可读的输入源（用于FFmpeg等）
     pub async fn get_input_uri(&mut self) -> String {
         self.wait_for_startup().await;
         match self {
@@ -218,23 +189,18 @@ impl StreamOutput {
         }
     }
 
-    /// 等待HTTP服务器启动
     async fn wait_for_startup(&mut self) {
         let process = match self {
             StreamOutput::Pipe(process) => process,
-            StreamOutput::Http { url, process } => process,
+            StreamOutput::Http { process, .. } => process,
         };
+
         match tokio::time::timeout(Duration::from_secs(5), process.wait()).await {
-            Ok(code) => {
-                info!("StreamOutput Exited with code {:?}", code);
-            }
-            Err(e) => {
-                error!(e=?e, "Timed out waiting for stream output");
-            }
+            Ok(code) => info!("StreamOutput exited with code {:?}", code),
+            Err(e) => error!(e = ?e, "Timed out waiting for stream output"),
         }
     }
 
-    /// 获取stdout（仅管道模式）
     pub fn take_stdout(&mut self) -> Option<ChildStdout> {
         match self {
             StreamOutput::Pipe(child) => child.stdout.take(),
@@ -243,14 +209,14 @@ impl StreamOutput {
     }
 
     pub async fn stop(&mut self) {
-        info!("准备停止stream terminated");
+        info!("Preparing to stop stream terminated");
         let child = match self {
             StreamOutput::Pipe(c) => c,
             StreamOutput::Http { process, .. } => process,
         };
 
-        let _ = child.kill().await; // 强制终止
-        let _ = child.wait().await; // 回收资源
-        info!("成功stream terminated");
+        let _ = child.kill().await;
+        let _ = child.wait().await;
+        info!("Stream terminated");
     }
 }

--- a/crates/biliup-cli/src/server/core/monitor.rs
+++ b/crates/biliup-cli/src/server/core/monitor.rs
@@ -5,8 +5,8 @@ use crate::server::infrastructure::connection_pool::ConnectionPool;
 use crate::server::infrastructure::context::{Context, PluginContext, Stage, Worker, WorkerStatus};
 use crate::server::infrastructure::models::StreamerInfo;
 use async_channel::Sender;
-use ormlite::Model;
 use ormlite::model::ModelBuilder;
+use ormlite::Model;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, RwLock};
@@ -84,10 +84,11 @@ impl Monitor {
             let url = room.get_streamer().url.clone();
             let interval = room.get_config().event_loop_interval;
             let mut ctx = PluginContext::new(room.clone(), self.pool.clone());
-            // 检查直播状态
+            // 检查直播状态，避免单次探测卡住整个轮询循环。
             let mut downloader = plugin.create_downloader(&mut ctx);
-            match downloader.check_stream().await {
-                Ok(StreamStatus::Live { mut stream_info }) => {
+            let check_timeout = Duration::from_secs(interval.clamp(5, 30));
+            match tokio::time::timeout(check_timeout, downloader.check_stream()).await {
+                Ok(Ok(StreamStatus::Live { mut stream_info })) => {
                     let sql_no_id = &stream_info.streamer_info;
                     let insert = match StreamerInfo::builder()
                         .url(sql_no_id.url.clone())
@@ -122,13 +123,21 @@ impl Monitor {
                         info!("成功开始录制 {}", url)
                     }
                 }
-                Ok(StreamStatus::Offline) => {
+                Ok(Ok(StreamStatus::Offline)) => {
                     self.wake_waker(room.id()).await;
                     debug!(url = ctx.live_streamer().url, "未开播")
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     self.wake_waker(room.id()).await;
                     error!(e=?e, ctx=ctx.live_streamer().url,"检查直播间出错")
+                }
+                Err(_) => {
+                    self.wake_waker(room.id()).await;
+                    warn!(
+                        url = ctx.live_streamer().url,
+                        timeout = ?check_timeout,
+                        "检查直播间超时"
+                    )
                 }
             };
             // 等待下一次检查
@@ -148,7 +157,13 @@ impl Monitor {
         let (send, recv) = oneshot::channel();
         let msg = ActorMessage::Add(send, worker.clone());
         let _ = self.sender.send(msg).await;
-        let plugin = recv.await.expect("Actor task has been killed")?;
+        let plugin = match recv.await {
+            Ok(plugin) => plugin?,
+            Err(_) => {
+                warn!("Actor task has been killed while adding worker");
+                return None;
+            }
+        };
 
         self.rooms_handle_pool(plugin.clone());
         Some(plugin)
@@ -162,7 +177,9 @@ impl Monitor {
         let (send, recv) = oneshot::channel();
         let msg = ActorMessage::AddPlugin(send, plugin);
         let _ = self.sender.send(msg).await;
-        recv.await.expect("Actor task has been killed")
+        if recv.await.is_err() {
+            warn!("Actor task has been killed while adding plugin");
+        }
     }
 
     /// 删除指定ID的工作器
@@ -182,10 +199,14 @@ impl Monitor {
         // 忽略发送错误。如果发送失败，下面的recv.await也会失败
         // 没有必要检查两次失败
         let _ = self.sender.send(msg).await;
-        if let Some(worker) = recv.await.expect("Actor task has been killed") {
-            worker
-                .change_status(Stage::Download, WorkerStatus::Idle)
-                .await;
+        match recv.await {
+            Ok(Some(worker)) => {
+                worker
+                    .change_status(Stage::Download, WorkerStatus::Idle)
+                    .await;
+            }
+            Ok(None) => {}
+            Err(_) => warn!("Actor task has been killed while deleting worker"),
         }
     }
 
@@ -206,7 +227,13 @@ impl Monitor {
         // 忽略发送错误。如果发送失败，下面的recv.await也会失败
         // 没有必要检查两次失败
         let _ = self.sender.send(msg).await;
-        recv.await.expect("Actor task has been killed")
+        match recv.await {
+            Ok(result) => result,
+            Err(_) => {
+                warn!("Actor task has been killed while getting worker");
+                None
+            }
+        }
     }
 
     /// 删除指定ID的工作器
@@ -223,7 +250,13 @@ impl Monitor {
         // 忽略发送错误。如果发送失败，下面的recv.await也会失败
         // 没有必要检查两次失败
         let _ = self.sender.send(msg).await;
-        recv.await.expect("Actor task has been killed")
+        match recv.await {
+            Ok(result) => result,
+            Err(_) => {
+                warn!("Actor task has been killed while getting all workers");
+                Vec::new()
+            }
+        }
     }
 
     /// 获取下一个要处理的工作器
@@ -240,7 +273,13 @@ impl Monitor {
         // 忽略发送错误。如果发送失败，下面的recv.await也会失败
         // 没有必要检查两次失败
         let _ = self.sender.send(msg).await;
-        recv.await.expect("Actor task has been killed")
+        match recv.await {
+            Ok(result) => result,
+            Err(_) => {
+                warn!("Actor task has been killed while fetching next worker");
+                None
+            }
+        }
     }
 
     /// 放回工作队列
@@ -257,7 +296,13 @@ impl Monitor {
 
         // 忽略发送错误
         let _ = self.sender.send(msg).await;
-        let plugin = recv.await.expect("Actor task has been killed")?;
+        let plugin = match recv.await {
+            Ok(plugin) => plugin?,
+            Err(_) => {
+                warn!("Actor task has been killed while waking worker");
+                return None;
+            }
+        };
         self.rooms_handle_pool(plugin.clone());
         Some(plugin)
     }
@@ -273,7 +318,9 @@ impl Monitor {
 
         // 忽略发送错误
         let _ = self.sender.send(msg).await;
-        recv.await.expect("Actor task has been killed")
+        if recv.await.is_err() {
+            warn!("Actor task has been killed while making worker");
+        }
     }
 
     fn spawn_monitor_task(
@@ -288,30 +335,33 @@ impl Monitor {
 
     fn rooms_handle_pool(self: &Arc<Self>, plugin: Arc<dyn DownloadPlugin + Send + Sync>) {
         let platform_name = plugin.name().to_owned();
-        match self.monitors.write().unwrap().entry(platform_name.clone()) {
-            Entry::Occupied(mut entry) => {
-                // 已经有一个任务了，检查是否结束
-                if entry.get().is_finished() {
-                    // 旧任务已经结束，重新 spawn 一个
+        match self.monitors.write() {
+            Ok(mut monitors) => match monitors.entry(platform_name.clone()) {
+                Entry::Occupied(mut entry) => {
+                    // 已经有一个任务了，检查是否结束
+                    if entry.get().is_finished() {
+                        // 旧任务已经结束，重新 spawn 一个
+                        let handle = Self::spawn_monitor_task(
+                            Arc::clone(self),
+                            plugin.clone(),
+                            platform_name.clone(),
+                        );
+                        entry.insert(handle); // 替换旧的 JoinHandle
+                    } else {
+                        // 任务还在跑，不做任何事
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    // 没有任务，正常 spawn
                     let handle = Self::spawn_monitor_task(
                         Arc::clone(self),
                         plugin.clone(),
                         platform_name.clone(),
                     );
-                    entry.insert(handle); // 替换旧的 JoinHandle
-                } else {
-                    // 任务还在跑，不做任何事
+                    entry.insert(handle);
                 }
-            }
-            Entry::Vacant(entry) => {
-                // 没有任务，正常 spawn
-                let handle = Self::spawn_monitor_task(
-                    Arc::clone(self),
-                    plugin.clone(),
-                    platform_name.clone(),
-                );
-                entry.insert(handle);
-            }
+            },
+            Err(_) => warn!("monitors lock poisoned"),
         }
     }
 }
@@ -502,7 +552,9 @@ impl RoomsActor {
         // 如果内部Vec是空的，迭代结束（虽然是循环迭代器，但空集合无法产生任何值）
         let arc = self.platforms.get_mut(platform_name)?.pop_front()?;
 
-        *arc.downloader_status.write().unwrap() = WorkerStatus::Pending;
+        if let Ok(mut guard) = arc.downloader_status.write() {
+            *guard = WorkerStatus::Pending;
+        }
 
         Some(arc)
     }
@@ -511,9 +563,14 @@ impl RoomsActor {
     fn push_back(&mut self, id: i64) -> Option<Arc<dyn DownloadPlugin + Send + Sync>> {
         // 在总数组中找不到，说明该房间已被移除我们也不放回
         let worker = self.get_worker(id)?;
-        if let WorkerStatus::Pause = *worker.downloader_status.write().unwrap() {
-            // 暂停状态则不放回
-            warn!("Paused room [{}]", worker.live_streamer.url);
+        if let Ok(mut guard) = worker.downloader_status.write() {
+            if let WorkerStatus::Pause = *guard {
+                // 暂停状态则不放回
+                warn!("Paused room [{}]", worker.live_streamer.url);
+                return None;
+            }
+        } else {
+            warn!("downloader status lock poisoned while pushing back");
             return None;
         }
         for (name, queue) in self.platforms.iter_mut() {
@@ -528,7 +585,9 @@ impl RoomsActor {
         self.platforms
             .get_mut(plugin.name())?
             .push_back(worker.clone());
-        *worker.downloader_status.write().unwrap() = WorkerStatus::Idle;
+        if let Ok(mut guard) = worker.downloader_status.write() {
+            *guard = WorkerStatus::Completed;
+        }
         Some(plugin)
     }
 
@@ -586,4 +645,75 @@ impl RoomsActor {
 
 fn reuse_vec_arc<'a, T: 'a, U: Iterator<Item = &'a Arc<T>>>(v: &mut U) -> Vec<Arc<T>> {
     v.into_iter().cloned().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::core::plugin::{DownloadBase, DownloadPlugin, StreamStatus};
+    use crate::server::errors::AppError;
+    use crate::server::infrastructure::connection_pool::ConnectionPool;
+    use crate::server::infrastructure::context::{Context, PluginContext};
+    use crate::server::infrastructure::models::StreamerInfo;
+    use async_trait::async_trait;
+    use error_stack::Report;
+    use std::sync::Arc;
+
+    struct DummyDownloader;
+
+    #[async_trait]
+    impl DownloadBase for DummyDownloader {
+        async fn check_stream(&mut self) -> Result<StreamStatus, Report<AppError>> {
+            Ok(StreamStatus::Offline)
+        }
+    }
+
+    struct DummyPlugin;
+
+    impl DownloadPlugin for DummyPlugin {
+        fn matches(&self, url: &str) -> bool {
+            url.contains("dummy")
+        }
+
+        fn create_downloader(&self, _ctx: &mut PluginContext) -> Box<dyn DownloadBase> {
+            Box::new(DummyDownloader)
+        }
+
+        fn name(&self) -> &str {
+            "dummy"
+        }
+    }
+
+    #[test]
+    fn reuse_vec_arc_clones_all_items() {
+        let items = vec![Arc::new(1_u32), Arc::new(2_u32), Arc::new(3_u32)];
+        let mut iter = items.iter();
+        let cloned = reuse_vec_arc(&mut iter);
+        assert_eq!(cloned.len(), 3);
+        assert_eq!(*cloned[0], 1);
+        assert_eq!(*cloned[1], 2);
+        assert_eq!(*cloned[2], 3);
+    }
+
+    #[test]
+    fn matches_returns_first_matching_plugin() {
+        let (sender, receiver) = tokio::sync::mpsc::channel(1);
+        drop(sender);
+        let actor = RoomsActor::new(receiver);
+        let plugin = Arc::new(DummyPlugin);
+        let mut actor = actor;
+        actor.add_plugin(plugin.clone());
+
+        let matched = actor.matches("https://example.com/dummy/live");
+        assert!(matched.is_some());
+        assert_eq!(matched.unwrap().name(), "dummy");
+    }
+
+    #[test]
+    fn worker_status_debug_names_are_stable() {
+        assert_eq!(format!("{:?}", WorkerStatus::Pending), "Pending");
+        assert_eq!(format!("{:?}", WorkerStatus::Completed), "Completed");
+        assert_eq!(format!("{:?}", WorkerStatus::Idle), "Idle");
+        assert_eq!(format!("{:?}", WorkerStatus::Pause), "Pause");
+    }
 }

--- a/crates/biliup-cli/src/server/core/plugin/twitch.rs
+++ b/crates/biliup-cli/src/server/core/plugin/twitch.rs
@@ -13,7 +13,7 @@ use error_stack::{IntoReport, Report, ResultExt};
 use regex::Regex;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -24,14 +24,13 @@ use tracing::{error, warn};
 const CLIENT_ID: &str = "kimne78kx3ncx6brgo4mv6wki5h1ko";
 
 pub struct Twitch {
-    re: Regex,
+    re: Option<Regex>,
 }
 
 impl Twitch {
     fn new() -> Twitch {
         Twitch {
-            re: Regex::new(r"https?://(?:(?:www|go|m)\.)?twitch\.tv/(?P<id>[0-9_a-zA-Z]+)")
-                .unwrap(),
+            re: Regex::new(r"https?://(?:(?:www|go|m)\.)?twitch\.tv/(?P<id>[0-9_a-zA-Z]+)").ok(),
         }
     }
 }
@@ -65,7 +64,7 @@ impl DownloadBase for TwitchDownloader {
 
 impl DownloadPlugin for Twitch {
     fn matches(&self, url: &str) -> bool {
-        self.re.is_match(url)
+        self.re.as_ref().is_some_and(|re| re.is_match(url))
     }
 
     fn create_downloader(&self, ctx: &mut PluginContext) -> Box<dyn DownloadBase> {
@@ -118,7 +117,7 @@ struct PlaybackAccessToken {
 // Twitch 下载器
 pub struct TwitchDownloader {
     url: String,
-    re: Regex,
+    re: Option<Regex>,
     twitch_danmaku: bool,
     twitch_disable_ads: bool,
     danmaku: Option<Arc<dyn DanmakuClient + Send + Sync>>,
@@ -126,7 +125,7 @@ pub struct TwitchDownloader {
 }
 
 impl TwitchDownloader {
-    pub fn new(name: &str, url: String, re: Regex) -> Self {
+    pub fn new(name: &str, url: String, re: Option<Regex>) -> Self {
         Self {
             url,
             re,
@@ -140,7 +139,8 @@ impl TwitchDownloader {
     pub async fn acheck_stream(&self) -> AppResult<StreamStatus> {
         let channel_name = self
             .re
-            .captures(&self.url)
+            .as_ref()
+            .and_then(|re| re.captures(&self.url))
             .and_then(|caps| caps.name("id"))
             .map(|m| m.as_str().to_lowercase())
             .ok_or_else(|| AppError::Custom("Invalid URL".to_string()))?;
@@ -220,7 +220,7 @@ impl TwitchDownloader {
                     date: Utc::now(),
                     live_cover_path: live_cover_url,
                 },
-                suffix: media_ext_from_url(&raw_stream_url).unwrap(),
+                suffix: media_ext_from_url(&raw_stream_url).unwrap_or_else(|| "m3u8".to_string()),
                 raw_stream_url,
                 platform: "twitch".to_string(),
                 stream_headers: HashMap::new(),
@@ -257,12 +257,14 @@ impl TwitchDownloader {
         let mut live_urls = Vec::new();
 
         for (index, gql) in gql_list.iter().enumerate() {
-            if let Some(data) = &gql.data
-                && let Some(user) = &data.user
-                && let Some(stream) = &user.stream
-                && stream.stream_type.as_deref() == Some("live")
-            {
-                live_urls.push(check_urls[index].clone());
+            if let Some(data) = &gql.data {
+                if let Some(user) = &data.user {
+                    if let Some(stream) = &user.stream {
+                        if stream.stream_type.as_deref() == Some("live") {
+                            live_urls.push(check_urls[index].clone());
+                        }
+                    }
+                }
             }
         }
 
@@ -271,12 +273,17 @@ impl TwitchDownloader {
 
     pub fn danmaku_init(&mut self) {
         if self.twitch_danmaku {
-            todo!()
+            warn!("Twitch danmaku is not implemented yet; continuing without it");
         }
     }
 
     fn gen_download_filename(&self) -> String {
-        todo!()
+        self.re
+            .as_ref()
+            .and_then(|re| re.captures(&self.url))
+            .and_then(|caps| caps.name("id"))
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_else(|| "twitch_stream".to_string())
     }
 }
 
@@ -311,15 +318,15 @@ impl TwitchUtils {
             );
 
             // 第二次重试时不使用 auth_token（因为已经失效）
-            if retry == 0
-                && let Some(auth_token) = Self::get_auth_token()
-            {
-                headers.insert(
-                    "Authorization",
-                    format!("OAuth {}", auth_token)
-                        .parse()
-                        .change_context(AppError::Unknown)?,
-                );
+            if retry == 0 {
+                if let Some(auth_token) = Self::get_auth_token() {
+                    headers.insert(
+                        "Authorization",
+                        format!("OAuth {}", auth_token)
+                            .parse()
+                            .change_context(AppError::Unknown)?,
+                    );
+                }
             }
 
             let client = Client::new();

--- a/crates/biliup-cli/src/server/core/plugin/yy.rs
+++ b/crates/biliup-cli/src/server/core/plugin/yy.rs
@@ -5,9 +5,9 @@ use crate::server::infrastructure::context::{Context, PluginContext};
 use crate::server::infrastructure::models::StreamerInfo;
 use async_trait::async_trait;
 use chrono::Utc;
-use error_stack::{Report, ResultExt, bail};
+use error_stack::{bail, Report, ResultExt};
 use regex::Regex;
-use reqwest::header::HeaderMap;
+use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::json;
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -35,8 +35,11 @@ impl DownloadBase for YYDownloader {
     async fn check_stream(&mut self) -> Result<StreamStatus, Report<AppError>> {
         let mut fake_headers = self.fake_headers.clone();
         // 设置headers
-        fake_headers.insert("content-type", "text/plain;charset=UTF-8".parse().unwrap());
-        fake_headers.insert("referer", "https://www.yy.com/".parse().unwrap());
+        fake_headers.insert(
+            "content-type",
+            HeaderValue::from_static("text/plain;charset=UTF-8"),
+        );
+        fake_headers.insert("referer", HeaderValue::from_static("https://www.yy.com/"));
 
         // 提取房间ID
         let rid = match self.url.split("www.yy.com/").nth(1) {
@@ -53,7 +56,7 @@ impl DownloadBase for YYDownloader {
         // 获取时间戳
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .expect("时间错误");
+            .change_context(AppError::Custom("时间错误".to_string()))?;
         let millis_13 = now.as_millis() as u64;
         let millis_10 = now.as_secs();
 
@@ -145,7 +148,7 @@ impl DownloadBase for YYDownloader {
                     date: Utc::now(),
                     live_cover_path: "".to_string(),
                 },
-                suffix: media_ext_from_url(&raw_stream_url).unwrap(),
+                suffix: media_ext_from_url(&raw_stream_url).unwrap_or_else(|| "flv".to_string()),
                 raw_stream_url,
                 platform: String::from("YY"),
                 stream_headers: HashMap::new(),
@@ -155,7 +158,7 @@ impl DownloadBase for YYDownloader {
 }
 
 pub struct YY {
-    re: Regex,
+    re: Option<Regex>,
 }
 
 impl Default for YY {
@@ -167,14 +170,14 @@ impl Default for YY {
 impl YY {
     pub fn new() -> Self {
         Self {
-            re: Regex::new(r"(?:https?://)?(?:www\.)?yy\.com").unwrap(),
+            re: Regex::new(r"(?:https?://)?(?:www\.)?yy\.com").ok(),
         }
     }
 }
 
 impl DownloadPlugin for YY {
     fn matches(&self, url: &str) -> bool {
-        self.re.is_match(url)
+        self.re.as_ref().is_some_and(|re| re.is_match(url))
     }
 
     fn create_downloader(&self, ctx: &mut PluginContext) -> Box<dyn DownloadBase> {

--- a/crates/biliup-cli/src/server/infrastructure/context.rs
+++ b/crates/biliup-cli/src/server/infrastructure/context.rs
@@ -1,12 +1,12 @@
 use crate::server::common::download::DownloadTask;
 use crate::server::common::util::Recorder;
-use crate::server::config::{Config, default_segment_time};
+use crate::server::config::{default_segment_time, Config};
 use crate::server::core::downloader::DownloadConfig;
 use crate::server::core::plugin::StreamInfoExt;
 use crate::server::infrastructure::connection_pool::ConnectionPool;
-use crate::server::infrastructure::models::StreamerInfo;
 use crate::server::infrastructure::models::live_streamer::LiveStreamer;
 use crate::server::infrastructure::models::upload_streamer::UploadStreamer;
+use crate::server::infrastructure::models::StreamerInfo;
 use axum::http::Extensions;
 use biliup::client::StatelessClient;
 use core::fmt;
@@ -78,8 +78,18 @@ impl Context {
 
     pub fn status(&self, stage: Stage) -> WorkerStatus {
         match stage {
-            Stage::Download => self.worker.downloader_status.read().unwrap().clone(),
-            Stage::Upload => self.worker.uploader_status.read().unwrap().clone(),
+            Stage::Download => self
+                .worker
+                .downloader_status
+                .read()
+                .map(|guard| guard.clone())
+                .unwrap_or_default(),
+            Stage::Upload => self
+                .worker
+                .uploader_status
+                .read()
+                .map(|guard| guard.clone())
+                .unwrap_or_default(),
         }
     }
 
@@ -189,7 +199,11 @@ impl Worker {
     /// 获取覆写配置
     /// 返回当前的配置副本
     pub fn get_config(&self) -> Config {
-        let mut cfg = self.config.read().unwrap().clone();
+        let mut cfg = self
+            .config
+            .read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default();
 
         if let Some(cfg_p) = self.live_streamer.override_cfg.clone() {
             cfg.apply(cfg_p)
@@ -205,25 +219,35 @@ impl Worker {
     pub async fn change_status(&self, stage: Stage, status: WorkerStatus) {
         match stage {
             Stage::Download => {
-                let task = if let WorkerStatus::Working(task) =
-                    &*self.downloader_status.read().unwrap()
-                    && !matches!(status, WorkerStatus::Working(_))
-                {
-                    Some(task.clone())
+                let current_status = self
+                    .downloader_status
+                    .read()
+                    .map(|guard| guard.clone())
+                    .unwrap_or_default();
+                let task = if let WorkerStatus::Working(task) = &current_status {
+                    if !matches!(status, WorkerStatus::Working(_)) {
+                        Some(task.clone())
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 };
 
-                *self.downloader_status.write().unwrap() = status;
+                if let Ok(mut guard) = self.downloader_status.write() {
+                    *guard = status;
+                }
 
-                if let Some(task) = task
-                    && let Err(e) = task.stop().await
-                {
-                    error!(error = ?e, "Failed to stop downloader");
+                if let Some(task) = task {
+                    if let Err(e) = task.stop().await {
+                        error!(error = ?e, "Failed to stop downloader");
+                    }
                 }
             }
             Stage::Upload => {
-                *self.uploader_status.write().unwrap() = status;
+                if let Ok(mut guard) = self.uploader_status.write() {
+                    *guard = status;
+                }
             }
         }
     }
@@ -265,6 +289,8 @@ pub enum WorkerStatus {
     Working(Arc<DownloadTask>),
     /// 等待中
     Pending,
+    /// å½å¶å·²ç»ç»æ
+    Completed,
     /// 空闲状态（默认）
     #[default]
     Idle,
@@ -278,6 +304,7 @@ impl fmt::Debug for WorkerStatus {
         let name = match self {
             WorkerStatus::Working(_) => "Working",
             WorkerStatus::Pending => "Pending",
+            WorkerStatus::Completed => "Completed",
             WorkerStatus::Idle => "Idle",
             WorkerStatus::Pause => "Pause",
         };

--- a/crates/biliup-cli/src/server/infrastructure/models/hook_step.rs
+++ b/crates/biliup-cli/src/server/infrastructure/models/hook_step.rs
@@ -1,5 +1,5 @@
 use crate::server::errors::{AppError, AppResult};
-use error_stack::{ResultExt, bail};
+use error_stack::{bail, ResultExt};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::path::Path;
@@ -109,27 +109,33 @@ impl HookStep {
                 .change_context(AppError::Unknown)?;
         }
 
-        let stdout = process.stdout.take().unwrap();
-        let stderr = process.stderr.take().unwrap();
+        let stdout = process
+            .stdout
+            .take()
+            .ok_or(AppError::Custom("missing stdout pipe".to_string()))?;
+        let stderr = process
+            .stderr
+            .take()
+            .ok_or(AppError::Custom("missing stderr pipe".to_string()))?;
 
         let mut stdout_lines = BufReader::new(stdout).lines();
         let mut stderr_lines = BufReader::new(stderr).lines();
 
         loop {
             tokio::select! {
-                        line = stdout_lines.next_line() => {
-                            match line.change_context(AppError::Unknown)? {
-                                Some(l) => tracing::info!(target="user_cmd_stdout", "{}", l),
-                                None => break, // stdout EOF
-                            }
-                        }
-                        line = stderr_lines.next_line() => {
-                            match line.change_context(AppError::Unknown)? {
-                                Some(l) => tracing::warn!(target="user_cmd_stderr", "{}", l),
-                                None => break, // stderr EOF
-                            }
-                        }
+                line = stdout_lines.next_line() => {
+                    match line.change_context(AppError::Unknown)? {
+                        Some(l) => tracing::info!(target="user_cmd_stdout", "{}", l),
+                        None => break, // stdout EOF
                     }
+                }
+                line = stderr_lines.next_line() => {
+                    match line.change_context(AppError::Unknown)? {
+                        Some(l) => tracing::warn!(target="user_cmd_stderr", "{}", l),
+                        None => break, // stderr EOF
+                    }
+                }
+            }
         }
 
         // 等待进程完成并检查退出状态
@@ -137,9 +143,9 @@ impl HookStep {
 
         if !status.success() {
             bail!(AppError::Custom(format!(
-                        "Command failed with status: {}",
-                        status
-                    )));
+                "Command failed with status: {}",
+                status
+            )));
         }
 
         Ok(())

--- a/crates/biliup-cli/src/uploader.rs
+++ b/crates/biliup-cli/src/uploader.rs
@@ -1,24 +1,24 @@
-use crate::UploadLine;
 use crate::server::errors::{AppError, AppResult};
 use crate::upload_lock::UploadLock;
+use crate::UploadLine;
 use biliup::client::StatelessClient;
 use biliup::error::Kind;
 use biliup::uploader::bilibili::{BiliBili, Studio, Vid, Video};
 use biliup::uploader::credential::{Credential, LoginInfo};
 use biliup::uploader::line::Probe;
 use biliup::uploader::util::SubmitOption;
-use biliup::uploader::{VideoFile, credential, line, load_config};
+use biliup::uploader::{credential, line, load_config, VideoFile};
 use bytes::{Buf, Bytes};
 use clap::ValueEnum;
+use dialoguer::theme::ColorfulTheme;
 use dialoguer::Input;
 use dialoguer::Select;
-use dialoguer::theme::ColorfulTheme;
 use error_stack::ResultExt;
 use futures::{Stream, StreamExt};
 use image::Luma;
 use indicatif::{ProgressBar, ProgressStyle};
-use qrcode::QrCode;
 use qrcode::render::unicode;
+use qrcode::QrCode;
 use reqwest::Body;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsStr;
@@ -92,7 +92,11 @@ pub async fn login(user_cookie: PathBuf, proxy: Option<&str>) -> AppResult<()> {
         3 => login_by_browser(client).await?,
         4 => login_by_web_cookies(client).await?,
         5 => login_by_webqr_cookies(client).await?,
-        _ => panic!(),
+        _ => {
+            return Err(
+                AppError::Custom(format!("invalid login method selection: {selection}")).into(),
+            );
+        }
     };
     let file = std::fs::File::create(user_cookie).change_context_lazy(|| AppError::Unknown)?;
     serde_json::to_writer_pretty(&file, &info).change_context_lazy(|| AppError::Unknown)?;
@@ -138,7 +142,8 @@ pub async fn upload_by_command(
             .file_stem()
             .and_then(OsStr::to_str)
             .map(|s| s.to_string())
-            .unwrap();
+            .ok_or_else(|| AppError::Custom("video file name is missing a valid stem".into()))
+            .change_context_lazy(|| AppError::Unknown)?;
     }
     cover_up(&mut studio, &bili).await?;
     studio.videos = upload(&video_path, &bili, line, limit).await?;
@@ -390,7 +395,7 @@ pub async fn upload(
         Some(UploadLine::Cntx) => line::cntx(),
         Some(UploadLine::Antx) => line::antx(),
         Some(UploadLine::Attx) => line::attx(),
-        // Some(UploadLine::Bda) => line::bda(),
+        Some(UploadLine::Bda) => line::bda(),
         Some(UploadLine::Txa) => line::txa(),
         Some(UploadLine::Alia) => line::alia(),
         _ => Probe::probe(&client.client).await.unwrap_or_default(),
@@ -420,7 +425,9 @@ pub async fn upload(
 
         // 在开始上传前检查是否有其他进程正在等待限流恢复
         {
-            let lock = upload_lock.lock().unwrap();
+            let lock = upload_lock
+                .lock()
+                .map_err(|_| AppError::Custom("upload lock mutex poisoned".into()))?;
             if lock.is_locked() {
                 return Err(AppError::Custom(format!(
                     "另一个使用该账号 ({}) 的上传进程正在等待限流恢复，请稍后重试",
@@ -448,10 +455,22 @@ pub async fn upload(
                 5,
                 Some(move |e: &Kind| {
                     if matches!(e, Kind::RateLimit { .. }) {
-                        let mut acquired = lock_acquired_clone.lock().unwrap();
+                        let mut acquired = match lock_acquired_clone.lock() {
+                            Ok(guard) => guard,
+                            Err(_) => {
+                                warn!("lock_acquired mutex poisoned");
+                                return true;
+                            }
+                        };
                         if !*acquired {
                             // 第一次遇到限流错误，尝试获取锁
-                            let mut lock = upload_lock_clone.lock().unwrap();
+                            let mut lock = match upload_lock_clone.lock() {
+                                Ok(guard) => guard,
+                                Err(_) => {
+                                    warn!("upload_lock mutex poisoned");
+                                    return true;
+                                }
+                            };
                             match lock.try_acquire() {
                                 Ok(true) => {
                                     info!("检测到限流，成功获取上传锁，将进行重试");
@@ -481,8 +500,13 @@ pub async fn upload(
         };
 
         // 上传成功后释放锁
-        if *lock_acquired.lock().unwrap() {
-            let mut lock = upload_lock.lock().unwrap();
+        let should_release = *lock_acquired
+            .lock()
+            .map_err(|_| AppError::Custom("lock_acquired mutex poisoned".into()))?;
+        if should_release {
+            let mut lock = upload_lock
+                .lock()
+                .map_err(|_| AppError::Custom("upload lock mutex poisoned".into()))?;
             let _ = lock.release();
         }
         //Progress bar
@@ -596,13 +620,12 @@ pub async fn login_by_qrcode(credential: Credential) -> AppResult<LoginInfo> {
         .get_qrcode()
         .await
         .change_context_lazy(|| AppError::Unknown)?;
-    let code = QrCode::new(
-        value["data"]["url"]
-            .as_str()
-            .unwrap()
-            .replace("https", "http"),
-    )
-    .unwrap();
+    let qrcode_url = value["data"]["url"]
+        .as_str()
+        .ok_or_else(|| AppError::Custom(format!("missing qrcode url: {value}")))
+        .change_context_lazy(|| AppError::Unknown)?;
+    let code = QrCode::new(qrcode_url.replace("https", "http"))
+        .map_err(|e| AppError::Custom(format!("failed to build qrcode: {e}")))?;
     let image = code
         .render::<unicode::Dense1x2>()
         .dark_color(unicode::Dense1x2::Light)
@@ -615,7 +638,9 @@ pub async fn login_by_qrcode(credential: Credential) -> AppResult<LoginInfo> {
         "在Windows下建议使用Windows Terminal(支持utf8，可完整显示二维码)\n否则可能无法正常显示，此时请打开./qrcode.png扫码"
     );
     // Save the image.
-    image.save("qrcode.png").unwrap();
+    image
+        .save("qrcode.png")
+        .change_context_lazy(|| AppError::Custom("failed to save qrcode.png".into()))?;
     credential
         .login_by_qrcode(value)
         .await

--- a/crates/biliup/src/downloader/extractor/bilibili.rs
+++ b/crates/biliup/src/downloader/extractor/bilibili.rs
@@ -11,14 +11,22 @@ pub struct BiliLive {}
 #[async_trait]
 impl SiteDefinition for BiliLive {
     fn can_handle_url(&self, url: &str) -> bool {
-        regex::Regex::new(r"(?:https?://)?(?:(?:www|m|live)\.)?bilibili\.com")
-            .unwrap()
-            .is_match(url)
+        match regex::Regex::new(r"(?:https?://)?(?:(?:www|m|live)\.)?bilibili\.com") {
+            Ok(re) => re.is_match(url),
+            Err(_) => false,
+        }
     }
 
     async fn get_site(&self, url: &str, mut client: StatelessClient) -> Result<Site> {
-        let rid: u32 = match regex::Regex::new(r"/(\d+)").unwrap().captures(url) {
-            Some(captures) => captures[1].parse().unwrap(),
+        let rid: u32 = match regex::Regex::new(r"/(\d+)") {
+            Ok(re) => match re.captures(url) {
+                Some(captures) => captures[1]
+                    .parse()
+                    .map_err(|_| Error::Custom(format!("Wrong url: {url}")))?,
+                _ => {
+                    return Err(Error::Custom(format!("Wrong url: {url}")));
+                }
+            },
             _ => {
                 return Err(Error::Custom(format!("Wrong url: {url}")));
             }
@@ -105,7 +113,7 @@ impl SiteDefinition for BiliLive {
             name: "bilibili",
             title: room_info["data"]["room_info"]["title"]
                 .as_str()
-                .unwrap()
+                .ok_or_else(|| Error::Custom(format!("Missing room title: {room_info}")))?
                 .to_string(),
             direct_url,
             extension: Extension::Flv,

--- a/crates/biliup/src/downloader/extractor/douyu.rs
+++ b/crates/biliup/src/downloader/extractor/douyu.rs
@@ -13,9 +13,10 @@ pub struct DouyuLive;
 #[async_trait]
 impl SiteDefinition for DouyuLive {
     fn can_handle_url(&self, url: &str) -> bool {
-        regex::Regex::new(r"(?:https?://)?(?:(?:www|m)\.)?douyu\.com")
-            .unwrap()
-            .is_match(url)
+        match regex::Regex::new(r"(?:https?://)?(?:(?:www|m)\.)?douyu\.com") {
+            Ok(re) => re.is_match(url),
+            Err(_) => false,
+        }
     }
 
     async fn get_site(
@@ -34,7 +35,7 @@ impl SiteDefinition for DouyuLive {
         // Compile each pattern independently.
         let room_id = patterns
             .iter()
-            .map(|pat| regex::Regex::new(pat).unwrap())
+            .filter_map(|pat| regex::Regex::new(pat).ok())
             .find_map(|pat| pat.captures(&text))
             .map(|captures| captures[1].to_string())
             .ok_or_else(|| Error::Custom(format!("Wrong url: {url}")))?;
@@ -49,7 +50,7 @@ impl SiteDefinition for DouyuLive {
 
         let time = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .map_err(|_| Error::Custom("system time error".to_string()))?
             .as_micros();
         let mut hasher = Md5::new();
         hasher.update(format!("{room_id}{time}"));
@@ -72,23 +73,24 @@ impl SiteDefinition for DouyuLive {
             .await?
             .json()
             .await?;
-        if result["error"] == 0
-            && let Some(key) = regex::Regex::new(r"(\d{1,8}[0-9a-zA-Z]+)_?\d{0,4}(/playlist|.m3u8)")
-                .unwrap()
-                .captures(&result["data"]["rtmp_live"].to_string())
-        {
-            return Ok(Site {
-                name: "douyu",
-                title: room_info
-                    .get("room")
-                    .and_then(|room| room.get("room_name"))
-                    .and_then(|name| name.as_str())
-                    .unwrap_or_default()
-                    .to_string(),
-                direct_url: format!("https://hw-tct.douyucdn.cn/live/{}.flv?uuid=", &key[1]),
-                extension: Extension::Flv,
-                client,
-            });
+        if result["error"] == 0 {
+            if let Some(key) = regex::Regex::new(r"(\d{1,8}[0-9a-zA-Z]+)_?\d{0,4}(/playlist|.m3u8)")
+                .ok()
+                .and_then(|re| re.captures(&result["data"]["rtmp_live"].to_string()))
+            {
+                return Ok(Site {
+                    name: "douyu",
+                    title: room_info
+                        .get("room")
+                        .and_then(|room| room.get("room_name"))
+                        .and_then(|name| name.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                    direct_url: format!("https://hw-tct.douyucdn.cn/live/{}.flv?uuid=", &key[1]),
+                    extension: Extension::Flv,
+                    client,
+                });
+            }
         }
         Err(Error::Custom(result.to_string()))
     }

--- a/crates/biliup/src/downloader/extractor/huya.rs
+++ b/crates/biliup/src/downloader/extractor/huya.rs
@@ -10,9 +10,10 @@ pub struct HuyaLive {}
 #[async_trait]
 impl SiteDefinition for HuyaLive {
     fn can_handle_url(&self, url: &str) -> bool {
-        regex::Regex::new(r"(?:https?://)?(?:(?:www|m)\.)?huya\.com")
-            .unwrap()
-            .is_match(url)
+        match regex::Regex::new(r"(?:https?://)?(?:(?:www|m)\.)?huya\.com") {
+            Ok(re) => re.is_match(url),
+            Err(_) => false,
+        }
     }
 
     async fn get_site(&self, url: &str, client: StatelessClient) -> Result<Site> {
@@ -20,12 +21,16 @@ impl SiteDefinition for HuyaLive {
         // println!("{:?}", response);
 
         let text = response.text().await?;
-        let mut stream: Value = match regex::Regex::new(r"stream: (\{.+)\n.*?\};")
-            .unwrap()
-            .captures(&text)
-        {
-            Some(captures) => serde_json::from_str(&captures[1])?,
-            _ => {
+        let mut stream: Value = match regex::Regex::new(r"stream: (\{.+)\n.*?\};") {
+            Ok(re) => match re.captures(&text) {
+                Some(captures) => serde_json::from_str(&captures[1])?,
+                _ => {
+                    return Err(crate::downloader::error::Error::Custom(format!(
+                        "Not online: {text}"
+                    )));
+                }
+            },
+            Err(_) => {
                 return Err(crate::downloader::error::Error::Custom(format!(
                     "Not online: {text}"
                 )));
@@ -48,10 +53,26 @@ impl SiteDefinition for HuyaLive {
         // let ratio = ;
         let direct_url = format!(
             "{}/{}.{}?{}&ratio={}",
-            game_stream_info["sFlvUrl"].as_str().unwrap(),
-            game_stream_info["sStreamName"].as_str().unwrap(),
-            game_stream_info["sFlvUrlSuffix"].as_str().unwrap(),
-            game_stream_info["sFlvAntiCode"].as_str().unwrap(),
+            game_stream_info["sFlvUrl"].as_str().ok_or_else(|| {
+                crate::downloader::error::Error::Custom(format!(
+                    "Missing flv url: {game_stream_info}"
+                ))
+            })?,
+            game_stream_info["sStreamName"].as_str().ok_or_else(|| {
+                crate::downloader::error::Error::Custom(format!(
+                    "Missing stream name: {game_stream_info}"
+                ))
+            })?,
+            game_stream_info["sFlvUrlSuffix"].as_str().ok_or_else(|| {
+                crate::downloader::error::Error::Custom(format!(
+                    "Missing url suffix: {game_stream_info}"
+                ))
+            })?,
+            game_stream_info["sFlvAntiCode"].as_str().ok_or_else(|| {
+                crate::downloader::error::Error::Custom(format!(
+                    "Missing anti code: {game_stream_info}"
+                ))
+            })?,
             v_multi_stream_info[0]["iBitRate"].take()
         );
         // println!("{}", direct_url);
@@ -59,7 +80,9 @@ impl SiteDefinition for HuyaLive {
             name: "huya",
             title: game["gameLiveInfo"]["introduction"]
                 .as_str()
-                .unwrap()
+                .ok_or_else(|| {
+                    crate::downloader::error::Error::Custom(format!("Missing title: {game}"))
+                })?
                 .to_string(),
             direct_url,
             extension: Extension::Flv,

--- a/crates/biliup/src/downloader/hls.rs
+++ b/crates/biliup/src/downloader/hls.rs
@@ -37,7 +37,9 @@ pub async fn download(
                 _ => {
                     let mut file = File::create("test.fmp4")?;
                     file.write_all(&bs)?;
-                    panic!("Unable to parse the content.")
+                    return Err(crate::downloader::error::Error::Custom(
+                        "Unable to parse m3u8 media playlist".to_string(),
+                    ));
                 }
             }
         }
@@ -46,14 +48,20 @@ pub async fn download(
             info!("index {}", pl.media_sequence);
             pl
         }
-        Err(e) => panic!("Parsing error: \n{}", e),
+        Err(e) => {
+            return Err(crate::downloader::error::Error::Custom(format!(
+                "Parsing error: {e}"
+            )));
+        }
     };
     let mut previous_last_segment = 0;
+    let mut stagnant_reloads = 0;
     loop {
         if pl.segments.is_empty() {
             info!("Segments array is empty - stream finished");
             break;
         }
+        let mut progressed = false;
         let mut seq = pl.media_sequence;
         for segment in &pl.segments {
             if seq > previous_last_segment {
@@ -80,9 +88,24 @@ pub async fn download(
                     splitting.reset();
                 }
                 previous_last_segment = seq;
+                progressed = true;
             }
             seq += 1;
         }
+
+        if progressed {
+            stagnant_reloads = 0;
+        } else {
+            stagnant_reloads += 1;
+            if stagnant_reloads >= 3 {
+                info!(
+                    "No new segments after {} reloads - stream finished",
+                    stagnant_reloads
+                );
+                break;
+            }
+        }
+
         let resp = client.retryable(media_url.as_str()).await?;
         let bs = resp.bytes().await?;
         if let Ok((_, playlist)) = m3u8_rs::parse_media_playlist(&bs) {

--- a/crates/biliup/src/downloader/httpflv.rs
+++ b/crates/biliup/src/downloader/httpflv.rs
@@ -1,6 +1,6 @@
 use crate::downloader::flv_parser::{
-    AACPacketType, AVCPacketType, CodecId, FrameType, SoundFormat, TagData, TagHeader,
     aac_audio_packet_header, avc_video_packet_header, script_data, tag_data, tag_header,
+    AACPacketType, AVCPacketType, CodecId, FrameType, SoundFormat, TagData, TagHeader,
 };
 use crate::downloader::flv_writer::{FlvFile, FlvTag, TagDataHeader};
 use crate::downloader::util::{LifecycleFile, Segmentable};
@@ -62,8 +62,10 @@ pub(crate) async fn parse_flv(
         let flv_tag = match flv_tag_data {
             TagData::Audio(audio_data) => {
                 let packet_type = if audio_data.sound_format == SoundFormat::AAC {
-                    let (_, packet_header) = aac_audio_packet_header(audio_data.sound_data)
-                        .expect("Error in parsing aac audio packet header.");
+                    let (_, packet_header) = map_parse_err(
+                        aac_audio_packet_header(audio_data.sound_data),
+                        "aac audio packet header",
+                    )?;
                     if packet_header.packet_type == AACPacketType::SequenceHeader {
                         if aac_sequence_header.is_some() {
                             warn!("Unexpected aac sequence header tag. {tag_header:?}");
@@ -91,8 +93,10 @@ pub(crate) async fn parse_flv(
             }
             TagData::Video(video_data) => {
                 let (packet_type, composition_time) = if CodecId::H264 == video_data.codec_id {
-                    let (_, avc_video_header) = avc_video_packet_header(video_data.video_data)
-                        .expect("Error in parsing avc video packet header.");
+                    let (_, avc_video_header) = map_parse_err(
+                        avc_video_packet_header(video_data.video_data),
+                        "avc video packet header",
+                    )?;
                     if avc_video_header.packet_type == AVCPacketType::SequenceHeader {
                         if let Some((_, binary_data, _)) = &h264_sequence_header {
                             warn!("Unexpected h264 sequence header tag. {tag_header:?}");
@@ -123,7 +127,7 @@ pub(crate) async fn parse_flv(
                 }
             }
             TagData::Script => {
-                let (_, tag_data) = script_data(i).expect("Error in parsing script tag.");
+                let (_, tag_data) = map_parse_err(script_data(i), "script tag")?;
                 if on_meta_data.is_some() {
                     warn!("Unexpected script tag. {tag_header:?}");
                 }
@@ -168,8 +172,13 @@ pub(crate) async fn parse_flv(
                     segment.set_start_time(Duration::from_millis(timestamp));
                     segment.set_size_position(9 + 4);
 
-                    let (meta_header, meta_bytes, previous_meta_tag_size) =
-                        on_meta_data.as_ref().expect("on_meta_data does not exist");
+                    let Some((meta_header, meta_bytes, previous_meta_tag_size)) =
+                        on_meta_data.as_ref()
+                    else {
+                        return Err(crate::downloader::error::Error::Custom(
+                            "on_meta_data does not exist".to_string(),
+                        ));
+                    };
                     // onMetaData
                     flv_tags_cache.push((
                         *meta_header,
@@ -177,9 +186,11 @@ pub(crate) async fn parse_flv(
                         previous_meta_tag_size.clone(),
                     ));
                     // AACSequenceHeader
-                    let aac_sequence_header = aac_sequence_header
-                        .as_ref()
-                        .expect("aac_sequence_header does not exist");
+                    let Some(aac_sequence_header) = aac_sequence_header.as_ref() else {
+                        return Err(crate::downloader::error::Error::Custom(
+                            "aac_sequence_header does not exist".to_string(),
+                        ));
+                    };
                     flv_tags_cache.push((
                         aac_sequence_header.0,
                         aac_sequence_header.1.clone(),
@@ -190,7 +201,11 @@ pub(crate) async fn parse_flv(
                         flv_tags_cache.push(
                             h264_sequence_header
                                 .as_ref()
-                                .expect("h264_sequence_header does not exist")
+                                .ok_or_else(|| {
+                                    crate::downloader::error::Error::Custom(
+                                        "h264_sequence_header does not exist".to_string(),
+                                    )
+                                })?
                                 .clone(),
                         );
                     }
@@ -218,12 +233,12 @@ pub fn map_parse_err<'a, T>(
             msg.to_string(),
             needed,
         )),
-        Err(Err::Error(e)) => {
-            panic!("parse {msg} err: {e:?}")
-        }
-        Err(Err::Failure(f)) => {
-            panic!("{msg} Failure: {f:?}")
-        }
+        Err(Err::Error(e)) => Err(crate::downloader::error::Error::Custom(format!(
+            "parse {msg} err: {e:?}"
+        ))),
+        Err(Err::Failure(f)) => Err(crate::downloader::error::Error::Custom(format!(
+            "{msg} Failure: {f:?}"
+        ))),
     }
 }
 

--- a/crates/biliup/src/uploader/bilibili.rs
+++ b/crates/biliup/src/uploader/bilibili.rs
@@ -1,9 +1,9 @@
-use crate::ReqwestClientBuilderExt;
 use crate::error::{Kind, Result};
 use crate::uploader::credential::LoginInfo;
+use crate::ReqwestClientBuilderExt;
 use serde::ser::Error;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::collections::HashMap;
 
 use bon::Builder;
@@ -278,6 +278,10 @@ impl BiliBili {
         proxy: Option<&str>,
     ) -> Result<ResponseData> {
         let payload = {
+            let ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|e| Kind::Custom(format!("system time error: {e}")))?
+                .as_secs();
             let mut payload = json!({
                 "access_key": self.login_info.token_info.access_token,
                 "appkey": crate::credential::AppKeyStore::BCutAndroid.app_key(),
@@ -290,7 +294,7 @@ impl BiliBili {
                 "platform": "android",
                 "s_locale": "zh-Hans_CN",
                 "sdk_type": "mon",
-                "ts": std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
+                "ts": ts,
             });
 
             let urlencoded = serde_urlencoded::to_string(&payload)?;
@@ -328,6 +332,10 @@ impl BiliBili {
         proxy: Option<&str>,
     ) -> Result<ResponseData> {
         let payload = {
+            let ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|e| Kind::Custom(format!("system time error: {e}")))?
+                .as_secs();
             let mut payload = json!({
                 "access_key": self.login_info.token_info.access_token,
                 "appkey": crate::credential::AppKeyStore::BiliTV.app_key(),
@@ -339,7 +347,7 @@ impl BiliBili {
                 "platform": "android",
                 "s_locale": "zh-Hans_CN",
                 "statistics": "\"appId\":1,\"platform\":3,\"version\":\"7.80.0\",\"abtest\":\"\"",
-                "ts": std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
+                "ts": ts,
             });
 
             let urlencoded = serde_urlencoded::to_string(&payload)?;
@@ -379,13 +387,14 @@ impl BiliBili {
     ) -> Result<ResponseData> {
         let ts = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
+            .map_err(|e| Kind::Custom(format!("system time error: {e}")))?
             .as_millis();
         let csrf = self.get_csrf()?;
 
         let url_str = "https://member.bilibili.com/x/vu/web/add/v3";
         let params = [("t", ts.to_string()), ("csrf", csrf.to_string())];
-        let url = reqwest::Url::parse_with_params(url_str, &params).unwrap();
+        let url = reqwest::Url::parse_with_params(url_str, &params)
+            .map_err(|e| Kind::Custom(format!("invalid web submit url: {e}")))?;
 
         let cookie = self.get_cookie()?;
         let jar = reqwest::cookie::Jar::default();
@@ -421,7 +430,7 @@ impl BiliBili {
     pub async fn edit_by_web(&self, studio: &Studio) -> Result<serde_json::Value> {
         let ts = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
+            .map_err(|e| Kind::Custom(format!("system time error: {e}")))?
             .as_millis();
         let ret: serde_json::Value = self
             .client
@@ -449,6 +458,10 @@ impl BiliBili {
         proxy: Option<&str>,
     ) -> Result<serde_json::Value> {
         let payload = {
+            let ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|e| Kind::Custom(format!("system time error: {e}")))?
+                .as_secs();
             let mut payload = json!({
                 "access_key": self.login_info.token_info.access_token,
                 "appkey": crate::credential::AppKeyStore::BiliTV.app_key(),
@@ -460,7 +473,7 @@ impl BiliBili {
                 "platform": "android",
                 "s_locale": "zh-Hans_CN",
                 "statistics": "\"appId\":1,\"platform\":3,\"version\":\"7.80.0\",\"abtest\":\"\"",
-                "ts": std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
+                "ts": ts,
             });
 
             let urlencoded = serde_urlencoded::to_string(&payload)?;
@@ -622,7 +635,8 @@ impl BiliBili {
     async fn archives(&self, status: &str, page_num: u32) -> Result<Value> {
         let url_str = "https://member.bilibili.com/x/web/archives";
         let params = [("status", status), ("pn", &page_num.to_string())];
-        let url = reqwest::Url::parse_with_params(url_str, &params).unwrap();
+        let url = reqwest::Url::parse_with_params(url_str, &params)
+            .map_err(|e| Kind::Custom(format!("invalid archives url: {e}")))?;
 
         let cookie = self.get_cookie()?;
         let jar = reqwest::cookie::Jar::default();

--- a/crates/biliup/src/uploader/credential.rs
+++ b/crates/biliup/src/uploader/credential.rs
@@ -6,14 +6,14 @@ use std::path::Path;
 
 use crate::error::{Kind, Result};
 use crate::uploader::bilibili::{BiliBili, ResponseData};
-use base64::{Engine as _, engine::general_purpose};
+use base64::{engine::general_purpose, Engine as _};
 use cookie::Cookie;
 use md5::{Digest, Md5};
 use reqwest::header::{COOKIE, ORIGIN, REFERER, USER_AGENT};
 
-use rsa::{Pkcs1v15Encrypt, RsaPublicKey, pkcs8::DecodePublicKey};
+use rsa::{pkcs8::DecodePublicKey, Pkcs1v15Encrypt, RsaPublicKey};
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::{debug, info};
 use url::Url;
@@ -225,10 +225,11 @@ impl Credential {
         // The type of `payload` is `serde_json::Value`
         let mut rng = rand::thread_rng();
         let (key_hash, pub_key) = self.get_key().await?;
-        let pub_key = RsaPublicKey::from_public_key_pem(&pub_key).unwrap();
+        let pub_key = RsaPublicKey::from_public_key_pem(&pub_key)
+            .map_err(|e| Kind::Custom(format!("invalid public key: {e}")))?;
         let enc_data = pub_key
             .encrypt(&mut rng, Pkcs1v15Encrypt, (key_hash + password).as_bytes())
-            .expect("failed to encrypt");
+            .map_err(|e| Kind::Custom(format!("failed to encrypt password: {e}")))?;
         let encrypt_password = general_purpose::STANDARD_NO_PAD.encode(enc_data);
         let mut payload = json!({
             "actionKey": "appkey",
@@ -412,7 +413,10 @@ impl Credential {
             Some(ResponseValue::Value(data))
                 if !data["recaptcha_url"].as_str().unwrap_or("").is_empty() =>
             {
-                let url = data["recaptcha_url"].as_str().unwrap().to_string();
+                let url = data["recaptcha_url"]
+                    .as_str()
+                    .ok_or_else(|| Kind::Custom(format!("invalid recaptcha url: {data}")))?
+                    .to_string();
                 Err(Kind::NeedRecaptcha(url))
             }
             _ => Err(Kind::Custom(res.to_string())),
@@ -568,8 +572,9 @@ impl Credential {
             .form(&[("oauthKey", oauth_key)])
             .send()
             .await?.error_for_status()?;
-        self.login_by_web_cookies(&self.get_cookie("SESSDATA"), &self.get_cookie("bili_jct"))
-            .await
+        let sess_data = self.get_cookie("SESSDATA")?;
+        let bili_jct = self.get_cookie("bili_jct")?;
+        self.login_by_web_cookies(&sess_data, &bili_jct).await
     }
 
     pub async fn login_by_web_cookies(&self, sess_data: &str, bili_jct: &str) -> Result<LoginInfo> {
@@ -624,29 +629,37 @@ impl Credential {
     }
 
     fn set_cookie(&self, cookie_info: &serde_json::Value) {
-        let mut store = self.0.cookie_store.lock().unwrap();
-        for cookie in cookie_info["cookies"].as_array().unwrap() {
-            let cookie = Cookie::build((
-                cookie["name"].as_str().unwrap(),
-                cookie["value"].as_str().unwrap(),
-            ))
-            .domain("bilibili.com")
-            .into();
-
-            store
-                .insert_raw(&cookie, &Url::parse("https://bilibili.com/").unwrap())
-                .unwrap();
+        let Ok(mut store) = self.0.cookie_store.lock() else {
+            return;
+        };
+        let Some(cookies) = cookie_info["cookies"].as_array() else {
+            return;
+        };
+        let Ok(base_url) = Url::parse("https://bilibili.com/") else {
+            return;
+        };
+        for cookie in cookies {
+            let (Some(name), Some(value)) = (cookie["name"].as_str(), cookie["value"].as_str())
+            else {
+                continue;
+            };
+            let cookie = Cookie::build((name, value)).domain("bilibili.com").into();
+            let _ = store.insert_raw(&cookie, &base_url);
         }
     }
 
-    fn get_cookie(&self, name: &str) -> String {
-        let store = self.0.cookie_store.lock().unwrap();
+    fn get_cookie(&self, name: &str) -> Result<String> {
+        let store = self
+            .0
+            .cookie_store
+            .lock()
+            .map_err(|_| Kind::Custom("cookie store poisoned".into()))?;
         for item in store.iter_any() {
             if item.name() == name {
-                return item.value().to_string();
+                return Ok(item.value().to_string());
             }
         }
-        panic!("{name} not exist");
+        Err(Kind::Custom(format!("{name} not exist")))
     }
 }
 

--- a/crates/biliup/src/uploader/line.rs
+++ b/crates/biliup/src/uploader/line.rs
@@ -11,8 +11,9 @@ use crate::client::StatelessClient;
 use crate::error::Kind::{Custom, RateLimit};
 use crate::uploader::bilibili::{BiliBili, Video};
 use crate::uploader::line::upos::Upos;
-use std::time::Instant;
-use tracing::info;
+use std::time::{Duration, Instant};
+use tokio::time::timeout;
+use tracing::{info, warn};
 
 pub mod upos;
 
@@ -57,14 +58,15 @@ impl Parcel {
         };
 
         if video.title.is_none()
-            && let Some(filename) = self.video_file.filepath.file_stem().and_then(OsStr::to_str) {
-                // B站限制分P视频标题不能超过80字符，需要截断
-                video.title = Some(if filename.chars().count() >= 80 {
-                    Video::truncate_title(filename, 80)
-                } else {
-                    filename.to_string()
-                });
-            };
+            && let Some(filename) = self.video_file.filepath.file_stem().and_then(OsStr::to_str)
+        {
+            // B站限制分P视频标题不能超过80字符，需要截断
+            video.title = Some(if filename.chars().count() >= 80 {
+                Video::truncate_title(filename, 80)
+            } else {
+                filename.to_string()
+            });
+        };
         Ok(video)
     }
 }
@@ -89,18 +91,33 @@ impl Probe {
         let mut choice_line: Line = Default::default();
         for mut line in res.lines {
             let instant = Instant::now();
-            if Probe::ping(&res.probe, &format!("https:{}", line.probe_url), client)
-                .send()
-                .await?
-                .status()
-                .is_success()
-            {
-                line.cost = instant.elapsed().as_millis();
-                info!("{}: {}", line.query, line.cost);
-                if choice_line.cost > line.cost {
-                    choice_line = line
+            let probe_result = timeout(
+                Duration::from_secs(5),
+                Probe::ping(&res.probe, &format!("https:{}", line.probe_url), client).send(),
+            )
+            .await;
+            match probe_result {
+                Ok(Ok(response)) if response.status().is_success() => {
+                    line.cost = instant.elapsed().as_millis();
+                    info!("{}: {}", line.query, line.cost);
+                    if choice_line.cost > line.cost {
+                        choice_line = line
+                    }
                 }
-            };
+                Ok(Ok(response)) => {
+                    warn!(
+                        status = ?response.status(),
+                        query = %line.query,
+                        "upload line probe returned non-success status"
+                    );
+                }
+                Ok(Err(err)) => {
+                    warn!(error = ?err, query = %line.query, "upload line probe failed");
+                }
+                Err(_) => {
+                    warn!(query = %line.query, "upload line probe timed out");
+                }
+            }
         }
         Ok(choice_line)
     }
@@ -164,15 +181,16 @@ impl Line {
             // 尝试解析JSON错误响应，检测限流错误（code: 601）
             if let Ok(error_json) = serde_json::from_str::<serde_json::Value>(&response_text)
                 && let Some(code) = error_json.get("code").and_then(|c| c.as_i64())
-                    && code == 601 {
-                        let message = error_json
-                            .get("message")
-                            .and_then(|m| m.as_str())
-                            .unwrap_or("上传过快")
-                            .to_string();
-                        // 直接返回限流错误，让调用方决定如何处理
-                        return Err(RateLimit { code, message });
-                    }
+                && code == 601
+            {
+                let message = error_json
+                    .get("message")
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("上传过快")
+                    .to_string();
+                // 直接返回限流错误，让调用方决定如何处理
+                return Err(RateLimit { code, message });
+            }
 
             return Err(Custom(format!(
                 "Failed to pre_upload from {}",

--- a/crates/stream-gears/src/lib.rs
+++ b/crates/stream-gears/src/lib.rs
@@ -36,10 +36,16 @@ pub async fn download_with_hook(
     proxy: Option<&str>,
 ) -> PyResult<()> {
     let client = StatelessClient::new(headers, proxy);
-    let response = client.retryable(url).await.unwrap();
+    let response = client
+        .retryable(url)
+        .await
+        .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
     let mut connection = Connection::new(response);
     // let buf = &mut [0u8; 9];
-    let bytes = connection.read_frame(9).await.unwrap();
+    let bytes = connection
+        .read_frame(9)
+        .await
+        .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
     // response.read_exact(buf)?;
     // let out = File::create(format!("{}.flv", file_name)).expect("Unable to create file.");
     // let mut writer = BufWriter::new(out);
@@ -59,7 +65,9 @@ pub async fn download_with_hook(
         Err(e) => {
             error!("{e}");
             let file = LifecycleFile::with_hook(file_name, "ts", file_name_hook);
-            hls::download(url, &client, file, segment).await.unwrap();
+            hls::download(url, &client, file, segment)
+                .await
+                .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
         }
     }
     Ok(())
@@ -180,7 +188,8 @@ fn download_with_callback(
 
 #[pyfunction]
 fn login_by_cookies(file: String, proxy: Option<String>) -> PyResult<bool> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?;
     let result = rt.block_on(async { login::login_by_cookies(&file, proxy.as_deref()).await });
     match result {
         Ok(_) => Ok(true),
@@ -193,7 +202,8 @@ fn login_by_cookies(file: String, proxy: Option<String>) -> PyResult<bool> {
 
 #[pyfunction]
 fn send_sms(country_code: u32, phone: u64, proxy: Option<String>) -> PyResult<String> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?;
     let result =
         rt.block_on(async { login::send_sms(country_code, phone, proxy.as_deref()).await });
     match result {
@@ -207,9 +217,12 @@ fn send_sms(country_code: u32, phone: u64, proxy: Option<String>) -> PyResult<St
 
 #[pyfunction]
 fn login_by_sms(code: u32, ret: String, proxy: Option<String>) -> PyResult<bool> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?;
     let result = rt.block_on(async {
-        login::login_by_sms(code, serde_json::from_str(&ret).unwrap(), proxy.as_deref()).await
+        let value = serde_json::from_str(&ret)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?;
+        login::login_by_sms(code, value, proxy.as_deref()).await
     });
     match result {
         Ok(_) => Ok(true),
@@ -219,7 +232,8 @@ fn login_by_sms(code: u32, ret: String, proxy: Option<String>) -> PyResult<bool>
 
 #[pyfunction]
 fn get_qrcode(proxy: Option<String>) -> PyResult<String> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?;
     let result = rt.block_on(async { login::get_qrcode(proxy.as_deref()).await });
     match result {
         Ok(res) => Ok(res.to_string()),
@@ -232,12 +246,16 @@ fn get_qrcode(proxy: Option<String>) -> PyResult<String> {
 
 #[pyfunction]
 fn login_by_qrcode(ret: String, proxy: Option<String>) -> PyResult<String> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?;
     rt.block_on(async {
+        let value =
+            serde_json::from_str(&ret).map_err(|e| biliup::error::Kind::Custom(format!("{e}")))?;
         let info = Credential::new(proxy.as_deref())
-            .login_by_qrcode(serde_json::from_str(&ret).unwrap())
+            .login_by_qrcode(value)
             .await?;
-        let res = serde_json::to_string_pretty(&info).unwrap();
+        let res = serde_json::to_string_pretty(&info)
+            .map_err(|e| biliup::error::Kind::Custom(format!("{e}")))?;
         Ok::<_, biliup::error::Kind>(res)
     })
     .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(format!("{:#?}", err)))
@@ -249,7 +267,8 @@ fn login_by_web_cookies(
     bili_jct: String,
     proxy: Option<String>,
 ) -> PyResult<bool> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?;
     let result = rt.block_on(async {
         login::login_by_web_cookies(&sess_data, &bili_jct, proxy.as_deref()).await
     });
@@ -268,7 +287,8 @@ fn login_by_web_qrcode(
     dede_user_id: String,
     proxy: Option<String>,
 ) -> PyResult<bool> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?;
     let result = rt.block_on(async {
         login::login_by_web_qrcode(&sess_data, &dede_user_id, proxy.as_deref()).await
     });
@@ -314,7 +334,8 @@ fn upload(
     py.detach(|| {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
-            .build()?;
+            .build()
+            .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
         // 输出到控制台中
         // use of deprecated function `time::util::local_offset::set_soundness`: no longer needed; TZ is refreshed manually
         // unsafe {
@@ -400,7 +421,9 @@ pub fn main_loop(py: Python<'_>) -> PyResult<()> {
     //     args.push("server".to_string());
     // }
     match args.as_slice() {
-        &[] => todo!(),
+        &[] => {
+            args.push("server".to_string());
+        }
         &[_] => {
             args.push("server".to_string());
         }

--- a/crates/stream-gears/src/server.rs
+++ b/crates/stream-gears/src/server.rs
@@ -25,8 +25,8 @@ use pyo3::prelude::PyDictMethods;
 use pyo3::prelude::{PyAnyMethods, PyListMethods, PyModule};
 use pyo3::types::PyDict;
 use pyo3::types::{PyList, PyType};
-use pyo3::{Bound, Py, PyAny, PyResult, Python};
 use pyo3::{pyclass, pyfunction, pymethods};
+use pyo3::{Bound, Py, PyAny, PyResult, Python};
 use pythonize::pythonize;
 use std::collections::HashMap;
 use std::net::ToSocketAddrs;
@@ -37,12 +37,12 @@ use tracing::{debug, info, warn};
 use tracing_appender::rolling::Rotation;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{EnvFilter, reload};
+use tracing_subscriber::{reload, EnvFilter};
 
 #[derive(Debug)]
 pub struct PyPlugin {
     plugin: Arc<Py<PyType>>,
-    pattern: Regex,
+    pattern: Option<Regex>,
     name: String,
 }
 
@@ -50,7 +50,7 @@ impl PyPlugin {
     pub fn from_pytype(class: &Bound<PyType>) -> PyResult<Self> {
         let pattern = class.getattr("VALID_URL_BASE")?.to_string();
         // info!("{pattern}");
-        let re = Regex::new(&pattern).unwrap();
+        let re = Regex::new(&pattern).ok();
         let plugin = class.clone();
         let name: String = class.getattr("__name__")?.extract()?;
         // info!("发现插件类: {name}");
@@ -188,11 +188,13 @@ impl PyDownloader {
 #[async_trait]
 impl DownloadPlugin for PyPlugin {
     fn matches(&self, url: &str) -> bool {
-        if self.pattern.is_match(url).unwrap() {
-            // 找到匹配的部分
-            if let Some(mat) = self.pattern.find(url).unwrap() {
-                debug!("  匹配内容: {}", mat.as_str());
-                return true;
+        if let Some(pattern) = &self.pattern {
+            if pattern.is_match(url).unwrap_or(false) {
+                // 找到匹配的部分
+                if let Ok(Some(mat)) = pattern.find(url) {
+                    debug!("  匹配内容: {}", mat.as_str());
+                    return true;
+                }
             }
         }
         false
@@ -293,10 +295,10 @@ impl OnceConfig {
             .extract::<Bound<PyDict>>()?
             .get_item(key)?
         {
-            if bound.is_none()
-                && let Some(d) = default
-            {
-                return Ok(d);
+            if bound.is_none() {
+                if let Some(d) = default {
+                    return Ok(d);
+                }
             }
             // 尝试转换为字典并过滤
             return match bound.cast::<PyDict>() {
@@ -337,16 +339,19 @@ impl ConfigState {
         key: &str,
         default: Option<Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let guard = self.map.read().unwrap();
+        let guard = self
+            .map
+            .read()
+            .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("config state lock poisoned"))?;
         // serde_json::to_value(guard.deref())
         if let Some(bound) = pythonize(py, guard.deref())?
             .extract::<Bound<PyDict>>()?
             .get_item(key)?
         {
-            if bound.is_none()
-                && let Some(d) = default
-            {
-                return Ok(d);
+            if bound.is_none() {
+                if let Some(d) = default {
+                    return Ok(d);
+                }
             }
             // 尝试转换为字典并过滤
             return match bound.cast::<PyDict>() {
@@ -417,7 +422,11 @@ pub(crate) async fn _main(args: &[String]) -> AppResult<()> {
         // .max_log_files(3)
         // .build("logs") // try to build an appender that stores log files in `/var/log`
         .build("") // try to build an appender that stores log files in `/var/log`
-        .expect("initializing rolling file appender failed");
+        .map_err(|e| {
+            Report::new(AppError::Custom(format!(
+                "initializing rolling file appender failed: {e}"
+            )))
+        })?;
     // 或者按小时滚动
     // let file_appender = tracing_appender::rolling::hourly("logs", "upload.log");
 
@@ -513,15 +522,32 @@ pub(crate) async fn _main(args: &[String]) -> AppResult<()> {
             );
             let conn_pool = ConnectionManager::new_pool("data/data.sqlite3")
                 .await
-                .expect("could not initialize the database connection pool");
+                .map_err(|e| {
+                    Report::new(AppError::Custom(format!(
+                        "could not initialize the database connection pool: {e}"
+                    )))
+                })?;
 
-            *CONFIG.write().unwrap() = repositories::get_config(&conn_pool).await?;
+            *CONFIG
+                .write()
+                .map_err(|_| Report::new(AppError::Custom("config lock poisoned".to_string())))? =
+                repositories::get_config(&conn_pool).await?;
             let download_manager = DownloadManager::new(
-                CONFIG.read().unwrap().pool1_size,
-                CONFIG.read().unwrap().pool2_size,
+                CONFIG
+                    .read()
+                    .map_err(|_| Report::new(AppError::Custom("config lock poisoned".to_string())))?
+                    .pool1_size,
+                CONFIG
+                    .read()
+                    .map_err(|_| Report::new(AppError::Custom("config lock poisoned".to_string())))?
+                    .pool2_size,
                 conn_pool.clone(),
             );
-            let vec = from_py().unwrap();
+            let vec = from_py().map_err(|e| {
+                Report::new(AppError::Custom(format!(
+                    "failed to load python plugins: {e}"
+                )))
+            })?;
 
             for v in vec {
                 download_manager.add_plugin(Arc::new(v));
@@ -557,7 +583,9 @@ pub(crate) async fn _main(args: &[String]) -> AppResult<()> {
                 .to_socket_addrs()
                 .change_context(AppError::Unknown)?
                 .next()
-                .unwrap();
+                .ok_or_else(|| {
+                    Report::new(AppError::Custom("invalid bind/port address".to_string()))
+                })?;
             ApplicationController::serve(&addr, auth, service_register)
                 .await
                 .attach("could not initialize application routes")?;


### PR DESCRIPTION
﻿## 变更说明

这次提交主要围绕录制状态回收、上传链路稳定性和手动上传问题做了一组修复：

- 修复直播结束后 Web 端仍显示“直播中”的问题
- 增加录制结束后的二次下播确认，避免误判在线后无限重试
- 引入更明确的 `Completed` 状态，并在前端展示“已结束 / 上传中 / 已完成”
- 修复上传链路中 `bda` 线路未正确接入的问题
- 为上传线路自动探测增加超时和告警，避免手动上传长期卡在线路探测
- 清理一批下载器、上传器、平台解析器中的 `unwrap/expect/panic`，提高健壮性

## 影响范围

- 录制状态与调度
- 自动上传与手动上传
- 前端录播管理页状态展示
- 多个平台解析与下载异常处理

## 已验证

- 手动上传已能正常进入 `pre_upload`
- 直播结束后状态不再长期停留在“直播中”
- 上传线路探测相关修复已生效

## 备注

这次改动涉及多个稳定性相关文件，属于一组连续问题修复的汇总提交。
