### PR TITLE
fix(server): 上传失败后重建 segment 通道，避免后续段被静默丢弃

### DIFF
--- a/crates/biliup-cli/src/server/common/download.rs
+++ b/crates/biliup-cli/src/server/common/download.rs
@@ -66,6 +66,19 @@ impl SegmentEventProcessor {
     pub fn process(&mut self, event: SegmentInfo) -> AppResult<()> {
         // 验证文件有效性
         self.file_validator.validate(&event.prev_file_path)?;
+
+        // 上一轮 process_with_upload 可能因上传失败提前返回，UActor 已 drop rx，
+        // 这里挂着的 tx 是死的；丢弃后下面会重建一条新的管道。
+        if let Some(tx) = &self.channel
+            && tx.is_closed()
+        {
+            warn!(
+                url = self.ctx.live_streamer().url,
+                "upload channel closed by uploader, reopening"
+            );
+            self.channel = None;
+        }
+
         match &self.channel {
             None => {
                 let (tx, rx) = async_channel::bounded(32); // Use tokio channel for async


### PR DESCRIPTION
## 问题

`SegmentEventProcessor::process` 在第一次给某个 streamer 处理事件时会
创建一条 `async_channel::bounded(32)`：把 `rx` 发给 `UActor`，把 `tx`
缓存到 `self.channel`。`UActor` 收到 `SegmentEvent(rx, ctx)` 后调用
`process_with_upload(rx.inspect(...), ...)`，里面是

\`\`\`rust
while let Some(event) = rx.next().await {
    let video = upload_single_file(&upload_path, context).await?;
    ...
}
\`\`\`

只要 `upload_single_file` 报错，`?` 就会让整个 `process_with_upload`
返回 `Err`。`UActor.handle_message` 走完 `Err` 分支后，`rx` 随作用域
退出被 drop，**但 `processor.channel` 里的 `tx` 还活着**。

之后只要 `execute()` 还在重试循环里没结束（流没断、download 继续），
后续段都会落到 `Some(tx)` 分支：`tx.force_send(event)` 对已关闭通道返
回 `Err` → 日志只记一行 `Failed to process segment event: Failed to
send to buffer` → **该段直接丢弃**，不会被任何重试兜底，也不会写进 DB。

直到 download 侧 `max_retries` 用尽、`execute()` 返回，`processor`
被 drop，下一次重建才能重开管道。

## 影响

- 触发条件普通：任何一次上传出错（21566 / 网络抖动 / preupload 401
  / 转码错误 …）都会让该 streamer 的整条管道失活。
- 后果严重：之后所有该 streamer 的段被静默丢；用户看不出来，只能在
  journal 里翻 `Failed to send to buffer` 才发现。
- 实测：本机 34 个 streamer 24h 内出现 64 次该错误，集中在两个早先
  upload 失败过的 streamer 上，每 30min（`segment_time` 切段）和每次
  HLS `#EXT-X-DISCONTINUITY` 各丢一段。

\`\`\`
00:51:51 Process segment event failed: Unknown Error url=...A
00:53:08 Process segment event failed: Unknown Error url=...B
01:18:48 Failed to send to buffer  ← B 的 HLS discontinuity 后新段
01:19:19 Failed to send to buffer  ← B 的 HLS discontinuity 后新段
01:21:51 Failed to send to buffer  ← A 的 30min 切段
01:38:16 Failed to send to buffer
...（之后 4h 共 ~20 条，全部来自这两个 streamer）
\`\`\`

## 修复

进入 `match` 之前先用 `Sender::is_closed()` 探测，如果挂着的 `tx`
对应的 `rx` 已经被 UActor drop，就把 `self.channel` 置 `None`，复用
下面的「首次创建」分支重新发一份 `rx` 给 UActor，恢复管道。

整改 13 行，无 API 变化。

## 进一步思路（未在本 PR 内）

更彻底的方案是让 `pipeline_upload_videos` 不要因为单段上传失败就整个
退出，而是 catch 单段错误、继续消费 rx，这样不会出现 rx 被提前 drop
的情况。但那个改动语义更大（涉及失败段如何与 postprocessor 协调），
适合单独做。本 PR 先用最小改动止血。