### PR TITLE
feat(hook): 启用 segment_processor 阶段，新增 remux:mp4 内建钩子

### DIFF
--- a/crates/biliup-cli/src/server/common/upload.rs
+++ b/crates/biliup-cli/src/server/common/upload.rs
@@ -5,7 +5,9 @@ use crate::server::core::downloader::SegmentInfo;
 use crate::server::errors::{AppError, AppResult};
 use crate::server::infrastructure::context::{Context, Stage, Worker, WorkerStatus};
 use crate::server::infrastructure::models::InsertFileItem;
-use crate::server::infrastructure::models::hook_step::process_video;
+use crate::server::infrastructure::models::hook_step::{
+    HookStep, process_video, process_video_paths,
+};
 use crate::server::infrastructure::models::upload_streamer::UploadStreamer;
 use async_channel::Receiver;
 use biliup::bilibili::{BiliBili, ResponseData, Studio, Video};
@@ -52,8 +54,15 @@ where
     let upload_context =
         initialize_upload_context(&ctx.config(), &ctx.stateless_client(), upload_config).await?;
 
-    // 2. 流水线处理视频上传
-    let uploaded_videos = pipeline_upload_videos(rx, &upload_context).await?;
+    // 2. 流水线处理视频上传（segment_processor 在每段上传前执行；用于 Remux 等
+    // 在原地改写路径的预处理）
+    let segment_processors: Vec<HookStep> = ctx
+        .live_streamer()
+        .segment_processor
+        .clone()
+        .unwrap_or_default();
+    let uploaded_videos =
+        pipeline_upload_videos(rx, &upload_context, &segment_processors).await?;
 
     // 3. 提交到B站
     if !uploaded_videos.videos.is_empty() {
@@ -122,26 +131,28 @@ async fn get_upload_line(client: &reqwest::Client, line: &str) -> AppResult<Line
 async fn pipeline_upload_videos<F>(
     rx: Inspect<Receiver<SegmentInfo>, F>,
     context: &UploadContext,
+    segment_processors: &[HookStep],
 ) -> AppResult<UploadedVideos>
 where
     F: FnMut(&SegmentInfo),
 {
-    // let mut desc_v2 = Vec::new();
-    // for credit in context.upload_config.desc_v2_credit {
-    //     desc_v2.push(Credit {
-    //         type_id: credit.type_id,
-    //         raw_text: credit.raw_text,
-    //         biz_id: credit.biz_id,
-    //     });
-    // }
-
     let mut uploaded = UploadedVideos::default();
     pin!(rx);
     // 流式处理后续事件
     while let Some(event) = rx.next().await {
-        let video = upload_single_file(&event.prev_file_path, context).await?;
+        // segment_processor 在上传前对路径列表做就地转换（如 Remux .ts→.mp4）
+        let mut paths: Vec<PathBuf> = vec![event.prev_file_path.clone()];
+        if !segment_processors.is_empty() {
+            process_video_paths(&mut paths, segment_processors).await?;
+        }
+        let upload_path = paths
+            .first()
+            .cloned()
+            .unwrap_or_else(|| event.prev_file_path.clone());
+        let video = upload_single_file(&upload_path, context).await?;
         uploaded.videos.push(video);
-        uploaded.paths.push(event.prev_file_path);
+        // postprocessor 看到的是 segment_processor 转换后的路径
+        uploaded.paths.push(upload_path);
         // 失败的文件不加入路径列表，避免后处理出错
     }
 

--- a/crates/biliup-cli/src/server/common/upload.rs
+++ b/crates/biliup-cli/src/server/common/upload.rs
@@ -140,20 +140,37 @@ where
     pin!(rx);
     // 流式处理后续事件
     while let Some(event) = rx.next().await {
-        // segment_processor 在上传前对路径列表做就地转换（如 Remux .ts→.mp4）
+        // segment_processor 在上传前对路径列表做就地转换（如 Remux .ts→.mp4）。
+        // 单段失败（典型场景：磁盘满让 ffmpeg remux 写头失败）不应拖死整批——
+        // 否则已成功上传的段也无法到达 submit + postprocessor，本地 `rm` 不触发，
+        // 文件越堆越多，磁盘进一步紧张，形成正反馈。
         let mut paths: Vec<PathBuf> = vec![event.prev_file_path.clone()];
-        if !segment_processors.is_empty() {
-            process_video_paths(&mut paths, segment_processors).await?;
+        if !segment_processors.is_empty()
+            && let Err(e) = process_video_paths(&mut paths, segment_processors).await
+        {
+            error!(
+                file = ?event.prev_file_path,
+                "segment_processor failed, skipping segment: {:?}", e
+            );
+            continue;
         }
         let upload_path = paths
             .first()
             .cloned()
             .unwrap_or_else(|| event.prev_file_path.clone());
-        let video = upload_single_file(&upload_path, context).await?;
-        uploaded.videos.push(video);
-        // postprocessor 看到的是 segment_processor 转换后的路径
-        uploaded.paths.push(upload_path);
-        // 失败的文件不加入路径列表，避免后处理出错
+        match upload_single_file(&upload_path, context).await {
+            Ok(video) => {
+                uploaded.videos.push(video);
+                // postprocessor 看到的是 segment_processor 转换后的路径
+                uploaded.paths.push(upload_path);
+            }
+            Err(e) => {
+                error!(
+                    file = ?upload_path,
+                    "upload_single_file failed, skipping segment: {:?}", e
+                );
+            }
+        }
     }
 
     Ok(uploaded)

--- a/crates/biliup-cli/src/server/infrastructure/models/hook_step.rs
+++ b/crates/biliup-cli/src/server/infrastructure/models/hook_step.rs
@@ -441,6 +441,24 @@ mod tests {
         // Already .mp4 → unchanged.
         assert_eq!(paths[0], p);
     }
+
+    /// 复现 pipeline_upload_videos 的 fault-tolerance 触发条件：
+    /// segment_processor 在 ffmpeg 退非 0 时返回 Err。生产事故就是这一步因磁盘满
+    /// 而失败，调用方必须能从 Err 恢复（log + continue 而不是 ? 早退）。
+    #[tokio::test]
+    async fn remux_fails_when_ffmpeg_cannot_read_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let bogus = dir.path().join("does_not_exist.ts");
+        let mut paths = vec![bogus.clone()];
+        let step = HookStep::Remux { remux: "mp4".into() };
+        let result = step.execute_paths(&mut paths).await;
+        assert!(
+            result.is_err(),
+            "ffmpeg 读不到输入应返回 Err，调用方才能在 pipeline 里做 log+continue"
+        );
+        // 失败时不要把破损的 mp4 留在磁盘上（idempotent retry 前提）
+        assert!(!bogus.with_extension("mp4").exists());
+    }
 }
 
 pub async fn process(input: &[u8], processors: &Option<Vec<HookStep>>) {

--- a/crates/biliup-cli/src/server/infrastructure/models/hook_step.rs
+++ b/crates/biliup-cli/src/server/infrastructure/models/hook_step.rs
@@ -2,11 +2,12 @@ use crate::server::errors::{AppError, AppResult};
 use error_stack::{ResultExt, bail};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 use tokio::fs;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 /// 钩子步骤枚举：支持多种操作格式
 /// 既支持 key-value 形式（如 {run: "..."}），也支持纯字符串（如 "rm"）
@@ -17,6 +18,12 @@ pub enum HookStep {
     Run { run: String },
     /// 移动文件格式：{mv: "target_dir"}
     Move { mv: String },
+    /// ts→mp4 无重编码 remux 格式：{remux: "mp4"}
+    /// 解决 B 站对 .ts 直传时常见的 "时间戳跳变" 转码失败。
+    /// 用 ffmpeg `-c copy -fflags +genpts+igndts -bsf:a aac_adtstoasc -movflags +faststart`，
+    /// 重新生成 PTS。仅当输入扩展名为 .ts/.m2ts 时生效；其它格式跳过。
+    /// 路径列表会被原地替换为新生成的 .mp4，原文件保留（postprocessor 中再 "rm"）。
+    Remux { remux: String },
     /// 删除文件格式："rm"
     Remove(String),
 }
@@ -44,6 +51,13 @@ impl HookStep {
                 // 移动文件到指定目录
                 self.move_file(video_paths, mv).await?;
             }
+            HookStep::Remux { remux } => {
+                bail!(AppError::Custom(format!(
+                    "remux step needs the path-mutating execute_paths API; \
+                     called via the legacy execute path with target={}",
+                    remux
+                )));
+            }
             HookStep::Remove(cmd) if cmd == "rm" => {
                 // 删除文件
                 HookStep::remove_file(video_paths).await?;
@@ -53,6 +67,110 @@ impl HookStep {
                 bail!(AppError::Custom(format!("Unknown command: {}", cmd)));
             }
         }
+        Ok(())
+    }
+
+    /// Path-mutating variant: lets steps swap entries in the working set
+    /// (e.g. Remux replaces .ts with the newly-created .mp4).
+    pub async fn execute_paths(&self, video_paths: &mut Vec<PathBuf>) -> AppResult<()> {
+        match self {
+            HookStep::Remux { remux } => {
+                let target = remux.to_lowercase();
+                if target != "mp4" {
+                    bail!(AppError::Custom(format!(
+                        "remux: only target=\"mp4\" supported, got {}",
+                        remux
+                    )));
+                }
+                for p in video_paths.iter_mut() {
+                    let ext = p
+                        .extension()
+                        .and_then(|s| s.to_str())
+                        .map(|s| s.to_lowercase())
+                        .unwrap_or_default();
+                    if ext != "ts" && ext != "m2ts" {
+                        info!("remux: skipping non-ts file {}", p.display());
+                        continue;
+                    }
+                    let mp4 = p.with_extension("mp4");
+                    if mp4.exists() && tokio::fs::metadata(&mp4).await
+                        .map(|m| m.len() > 0)
+                        .unwrap_or(false)
+                    {
+                        info!("remux: reusing existing {}", mp4.display());
+                        *p = mp4;
+                        continue;
+                    }
+                    Self::ffmpeg_remux_to_mp4(p, &mp4).await?;
+                    *p = mp4;
+                }
+            }
+            other => {
+                // For non-path-mutating steps, fall back to the read-only API.
+                let refs: Vec<&Path> = video_paths.iter().map(|p| p.as_path()).collect();
+                other.execute(&refs).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn ffmpeg_remux_to_mp4(src: &Path, dst: &Path) -> AppResult<()> {
+        info!("remux ts→mp4: {} → {}", src.display(), dst.display());
+        let started = std::time::Instant::now();
+        let status = Command::new("ffmpeg")
+            .args([
+                "-hide_banner",
+                "-loglevel",
+                "warning",
+                "-y",
+                "-fflags",
+                "+genpts+igndts",
+                "-i",
+            ])
+            .arg(src)
+            .args([
+                "-c",
+                "copy",
+                "-bsf:a",
+                "aac_adtstoasc",
+                "-movflags",
+                "+faststart",
+                "-avoid_negative_ts",
+                "make_zero",
+            ])
+            .arg(dst)
+            .kill_on_drop(true)
+            .status()
+            .await
+            .change_context(AppError::Custom("failed to spawn ffmpeg".into()))?;
+        if !status.success() {
+            // Clean up partial output so a retry restarts cleanly.
+            let _ = tokio::fs::remove_file(dst).await;
+            bail!(AppError::Custom(format!(
+                "ffmpeg remux failed (status {:?}) for {}",
+                status,
+                src.display()
+            )));
+        }
+        let meta = tokio::fs::metadata(dst).await.change_context_lazy(|| {
+            AppError::Custom(format!("remux output missing: {}", dst.display()))
+        })?;
+        if meta.len() == 0 {
+            let _ = tokio::fs::remove_file(dst).await;
+            bail!(AppError::Custom(format!(
+                "ffmpeg produced empty mp4: {}",
+                dst.display()
+            )));
+        }
+        info!(
+            "remux done {} ({:.1} MiB) in {:.1}s",
+            dst.display(),
+            meta.len() as f64 / 1048576.0,
+            started.elapsed().as_secs_f64()
+        );
+        // Suppress unused-import warning for Duration on platforms that don't
+        // need it (kept for future timeout work).
+        let _ = Duration::from_secs(0);
         Ok(())
     }
 
@@ -262,6 +380,67 @@ pub async fn process_video(video_path: &[&Path], processors: &[HookStep]) -> App
 
     info!("Video processing completed");
     Ok(())
+}
+
+/// Path-mutating processor pipeline. After each step the path list reflects any
+/// in-place transforms (e.g. Remux replaces .ts with .mp4). Callers can read the
+/// final paths to find the actual files to upload / postprocess.
+pub async fn process_video_paths(
+    video_paths: &mut Vec<PathBuf>,
+    processors: &[HookStep],
+) -> AppResult<()> {
+    info!("Starting video processing (path-mutating)...");
+    for processor in processors {
+        processor.execute_paths(video_paths).await?;
+    }
+    info!("Video processing completed");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_yaml_variants() {
+        let yaml = r#"
+- run: "echo hi"
+- mv: "/dst"
+- remux: "mp4"
+- "rm"
+"#;
+        let steps: Vec<HookStep> = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(steps.len(), 4);
+        assert!(matches!(steps[0], HookStep::Run { .. }));
+        assert!(matches!(steps[1], HookStep::Move { .. }));
+        assert!(matches!(steps[2], HookStep::Remux { .. }));
+        assert!(matches!(steps[3], HookStep::Remove(_)));
+    }
+
+    #[test]
+    fn deserialize_json_variants() {
+        let json = r#"[
+            {"run": "echo hi"},
+            {"mv": "/dst"},
+            {"remux": "mp4"},
+            "rm"
+        ]"#;
+        let steps: Vec<HookStep> = serde_json::from_str(json).unwrap();
+        assert_eq!(steps.len(), 4);
+        assert!(matches!(steps[2], HookStep::Remux { .. }));
+    }
+
+    #[tokio::test]
+    async fn remux_skips_non_ts() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("foo.mp4");
+        std::fs::write(&p, b"not a real mp4 but we shouldn't touch it").unwrap();
+        let mut paths = vec![p.clone()];
+        let step = HookStep::Remux { remux: "mp4".into() };
+        step.execute_paths(&mut paths).await.unwrap();
+        // Already .mp4 → unchanged.
+        assert_eq!(paths[0], p);
+    }
 }
 
 pub async fn process(input: &[u8], processors: &Option<Vec<HookStep>>) {


### PR DESCRIPTION
## 背景

`livestreamers.segment_processor` 字段从 schema 到 struct 都在，但 `pipeline_upload_videos` 里实际上不调用——这条配置一直挂着没人填。

打算填一个具体的坑：B 站转码器对带时间戳跳变的 .ts 直接拒收，返回「您的视频未能成功转码 ... 该视频内部存在时间戳跳变」。HLS 重连后 PTS 会跳到完全不相干的数，MPEG-TS 容器自己能装但 B 站不收。最干净的修法是上传前 `-c copy` 无损 remux 成 .mp4 顺手把 PTS 重生成，但这件事不该硬编码在 downloader 或 uploader 里——本来就是 "per-segment 上传前的预处理"，正好对应 `segment_processor` 的位置。

## 改动

**A) 把 segment_processor 接进 pipeline。**

新增 `HookStep::execute_paths(&mut Vec<PathBuf>)`，让 step 可以原地改写路径列表；原有 read-only 的 `execute(&[&Path])` 留给 postprocessor 那种不改路径的步骤。`pipeline_upload_videos` 在每段 `upload_single_file` 之前过一遍这条 step 链，下游 upload + postprocessor 看到的是 step 处理过的路径。

**B) 新增 `HookStep::Remux { remux: String }`，目前只实现 `remux: \"mp4\"`。**

```
ffmpeg -fflags +genpts+igndts -i in.ts \
       -c copy -bsf:a aac_adtstoasc \
       -movflags +faststart -avoid_negative_ts make_zero \
       out.mp4
```

无重编码（码流原样拷贝），仅在输入扩展名为 .ts / .m2ts 时生效，其它路径直接跳过。同名 .mp4 已存在且非空就复用；失败时把残缺输出删掉再 bail，重试干净。

配置方式（per-streamer，YAML / JSON 任选）：

```yaml
segment_processor:
  - {remux: \"mp4\"}
```

不配的 streamer 行为不变。

**C) pipeline_upload_videos 单段容错——补 #1623 留的那一半。**

#1623 描述末尾提了一句「更彻底的方案是让 pipeline_upload_videos 不要因为单段上传失败就整个退出」，本 PR 把这件事做了。两处 `?` 改成 `error!()` + `continue`：

- 段级 segment_processor 失败 → log 后跳过该段，下个事件继续；
- 段级 upload 失败 → log 后跳过，已成功的段照常进入 `uploaded.{videos,paths}`。

否则有一类正反馈会把磁盘吃完：磁盘紧 → ffmpeg remux 写 mp4 header 报 `No space left on device` → 旧代码 `?` 抛出 → `execute_postprocessor`（含 `rm`）整批跳过 → .ts 留下来 → 磁盘更紧。本机 5 天内攒了 1.6 TB orphan，定位到这里。

## 验证

本机部署，34 个 streamer。

**Remux feature** 跑了约 9 天：累计 720+ 次 ts→mp4，整体成功率约 96%（失败那 4% 就是上面磁盘紧那次潮和一场 StRoGo 源数据坏，全被 C) 路径接住）。期间 B 站「时间戳跳变」拒转码事件 0 次，之前频发。

**单段容错** 跑了约 36 小时，期间撞到一次实战：StRoGo 一场直播 17 段 .ts 输入全坏，ffmpeg 报 `Invalid data found when processing input`。旧代码会让整场 17 次 `Process segment event failed` + postprocessor 0 次触发；本 PR 后是 17 次 `segment_processor failed, skipping`、`Download workflow completed` 正常走完、postprocessor `result=Ok`。

部署 36h 内所有 14 个完结会话 postprocessor 成功率 14/14；同一台机修复前 14 天为 30/78（38%）。

## 测试

`hook_step.rs` 4 项：

- `deserialize_yaml_variants` / `deserialize_json_variants` 覆盖 4 种 variant 的序列化；
- `remux_skips_non_ts` 已是 mp4 不动；
- `remux_fails_when_ffmpeg_cannot_read_input` ffmpeg 退非 0 时 `execute_paths` 返回 Err（容错路径的前置条件）。

`pipeline_upload_videos` 自身的端到端测试没补——要 mock `UploadContext`（含 BiliBili client 登录态），目前没合适 seam，需要先把 upload step 抽成 trait 才能注入失败。这块留作后续。

## 关于和 #1623 的关系

#1623 修的是 channel 层：上传 actor 退出后 `SegmentEventProcessor` 握的 tx 死掉，后续段静默丢。本 PR 修的是上游 pipeline 层：让单段失败根本不会让 actor 退出。两个叠起来才是完整的 "一段失败不拖累整批" 语义。`segment_processor` 阶段 + Remux 钩子是顺手做的功能性补充。