### PR TITLE
fix(log): 主程序日志写入 ds_update.log 而非 download.log（修复 web 实时日志页）

### DIFF
--- a/crates/stream-gears/src/server.rs
+++ b/crates/stream-gears/src/server.rs
@@ -161,19 +161,17 @@ pub(crate) async fn _main(args: &[String]) -> AppResult<()> {
         .with_line_number(true)
         .with_thread_ids(true);
 
-    // 按日期滚动，每天创建新文件
+    // 主程序日志写到工作目录下的 ds_update.log，文件名需与前端「实时日志-主程序运行日志」
+    // (web 端通过 ws 读取 ds_update.log) 保持一致。
+    // 此前 builder 链式调用重复设置，filename_prefix 被后一次 "download" 覆盖、rotation 被
+    // 后一次 NEVER 覆盖，实际生成的是 download.log，导致网页「主程序运行日志」一直提示文件不存在。
+    // 这里固定为不滚动的 ds_update.log（固定文件名便于前端 tail）。
     let file_appender = tracing_appender::rolling::RollingFileAppender::builder()
-        .rotation(Rotation::DAILY) // rotate log files once every hour
-        .rotation(Rotation::NEVER) // rotate log files once every hour
-        .filename_prefix("biliup") // log file names will be prefixed with `myapp.`
-        .filename_prefix("download") // log file names will be prefixed with `myapp.`
-        .filename_suffix("log") // log file names will be suffixed with `.log`
-        // .max_log_files(3)
-        // .build("logs") // try to build an appender that stores log files in `/var/log`
-        .build("") // try to build an appender that stores log files in `/var/log`
+        .rotation(Rotation::NEVER)
+        .filename_prefix("ds_update")
+        .filename_suffix("log")
+        .build("")
         .expect("initializing rolling file appender failed");
-    // 或者按小时滚动
-    // let file_appender = tracing_appender::rolling::hourly("logs", "upload.log");
 
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
 
@@ -200,7 +198,7 @@ pub(crate) async fn _main(args: &[String]) -> AppResult<()> {
 
     subscriber.init();
 
-    info!("Tracing initialized with daily rotation");
+    info!("Tracing initialized, file log: ds_update.log");
 
     match cli.command {
         Commands::Login => login(cli.user_cookie, cli.proxy.as_deref()).await?,


### PR DESCRIPTION
## 问题
Web 端「实时日志 → 主程序运行日志」始终显示「日志文件 ds_update.log 不存在」。

## 原因
`crates/stream-gears/src/server.rs` 初始化文件日志的 `RollingFileAppender::builder()` 链式调用重复设置了 `filename_prefix` 与 `rotation`，后一次覆盖前一次：

```rust
.rotation(Rotation::DAILY)
.rotation(Rotation::NEVER)      // 覆盖 -> NEVER
.filename_prefix("biliup")
.filename_prefix("download")    // 覆盖 -> download
.filename_suffix("log")
```

实际生成的文件名是 `download.log`，而前端「主程序运行日志」tab 经 `ws.rs` 读取的是默认的 `ds_update.log`，二者不一致，故该页面始终提示文件不存在。

## 修复
去掉重复的 builder 调用，固定生成不滚动的 `ds_update.log`（固定文件名便于前端 tail），并修正初始化日志里 "daily rotation" 的不实描述。

## 影响
仅日志文件名，无行为/接口变更。修复后 web「主程序运行日志」可正常实时显示。