### PR TITLE
fix(server): 让 submit_api=web 走 Web 投稿接口

### DIFF
--- a/crates/biliup-cli/src/server/common/upload.rs
+++ b/crates/biliup-cli/src/server/common/upload.rs
@@ -256,6 +256,10 @@ pub async fn submit_to_bilibili(
             .submit_by_bcut_android(studio, None)
             .await
             .change_context(AppError::Unknown)?,
+        SubmitOption::Web => bilibili
+            .submit_by_web(studio, None)
+            .await
+            .change_context(AppError::Unknown)?,
         _ => bilibili
             .submit_by_app(studio, None)
             .await

--- a/crates/biliup/src/uploader/util.rs
+++ b/crates/biliup/src/uploader/util.rs
@@ -19,8 +19,32 @@ impl FromStr for SubmitOption {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "app" => Ok(SubmitOption::App),
+            "web" => Ok(SubmitOption::Web),
             "bcutandroid" | "b-cut-android" | "bcut_android" => Ok(SubmitOption::BCutAndroid),
             _ => Err(format!("Unknown submit option: {}", s)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SubmitOption;
+    use std::str::FromStr;
+
+    #[test]
+    fn parse_submit_options() {
+        assert!(matches!(
+            SubmitOption::from_str("app").unwrap(),
+            SubmitOption::App
+        ));
+        assert!(matches!(
+            SubmitOption::from_str("web").unwrap(),
+            SubmitOption::Web
+        ));
+        assert!(matches!(
+            SubmitOption::from_str("bcut_android").unwrap(),
+            SubmitOption::BCutAndroid
+        ));
+        assert!(SubmitOption::from_str("unknown").is_err());
     }
 }


### PR DESCRIPTION
## 背景

`biliup upload --submit web` 现在已经能走 Web 投稿接口，配置上传那里也能传 `SubmitOption::Web`。

但 server 这边还有一处没有接上：`submit_api = "web"` 会先走 `SubmitOption::from_str()`，而这里目前不解析 `web`。后面的 `submit_to_bilibili()` 也没有 `SubmitOption::Web` 分支，所以这条路径最后会回到 App 投稿接口。

这样 WebUI 或边录边传这类走 server config 的上传，即使配置了 `submit_api: web`，实际也可能没有用到 Web 投稿接口。

## 改动

这个 PR 只改了两点：

1. `SubmitOption::from_str()` 支持解析 `web`
2. server 的 `submit_to_bilibili()` 在拿到 `SubmitOption::Web` 时调用 `submit_by_web()`

默认行为没有变。不配置 `submit_api` 时还是走 App 投稿接口。

## 测试

- `cargo test -p biliup parse_submit_options`
- `cargo test -p biliup-cli --no-run`

第二个检查需要前端构建产物 `out/` 存在。我本地临时放了一个最小 `out/index.html` 让 Rust 代码完成编译检查，检查后已经删掉，没有提交。