### PR TITLE
Build free-threaded wheels for Python 3.14t

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.13t
+          args: --release --out dist -i python3.14t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: ${{ matrix.platform.target == 'aarch64' && '2_28' || 'auto' }}
       - name: Upload wheels
@@ -104,7 +104,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.13t
+          args: --release --out dist -i python3.14t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -143,13 +143,13 @@ jobs:
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.13t
+          python-version: 3.14t
           architecture: ${{ matrix.platform.target }}
       - name: Build free-threaded wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.13t
+          args: --release --out dist -i python3.14t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -188,7 +188,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.13t
+          args: --release --out dist -i python3.14t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 问题

CI 自 6 月下旬起在 linux (ppc64le)、musllinux (armv7)、macos (aarch64) 等 job 上失败（其余 job 被连带取消），报错：

```
💥 maturin failed
  Caused by: Free-threaded Python interpreter is only supported on 3.14 and later.
```

例如 https://github.com/biliup/biliup/actions/runs/28236626316

## 原因

maturin-action 未固定 maturin 版本，始终使用最新版。maturin 1.14（2026-06 发布）在解释器解析层面拒绝了 free-threaded 3.13（`python3.13t`），free-threaded 仅支持 3.14+。当前 ci.yml 是 maturin 1.9.1 生成的，free-threaded 步骤仍使用 `-i python3.13t`。

Windows job 之所以没失败，是因为它先用 setup-python 安装了真实的 3.13t 解释器，maturin 走的是可执行文件查找路径而非版本字符串解析。

## 修复

与 maturin 1.14 的 `generate-ci` 模板对齐：

- 四个平台的 "Build free-threaded wheels" 步骤：`-i python3.13t` → `-i python3.14t`
- Windows 的 setup-python：`python-version: 3.13t` → `3.14t`

`requires-python = ">= 3.9"` 无上限，pyo3 0.27.1 支持 Python 3.14（含 free-threaded），cp314t wheel 可正常构建。