### PR TITLE
fix(hls): 拉取视频的时候默认选取最高画质的流

### DIFF
--- a/crates/biliup/src/downloader/hls.rs
+++ b/crates/biliup/src/downloader/hls.rs
@@ -27,7 +27,23 @@ pub async fn download(
     let mut pl = match m3u8_rs::parse_playlist(&bytes) {
         Ok((_i, Playlist::MasterPlaylist(pl))) => {
             info!("Master playlist:\n{:#?}", pl);
-            media_url = media_url.join(&pl.variants[0].uri)?;
+            // Pick the highest-bandwidth playable variant. The first variant is not
+            // necessarily the best quality (e.g. Twitch orders transcodes ahead of the
+            // source), so prefer the highest-bandwidth stream that carries a resolution.
+            // Skip I-frame (trick-play) streams, which are not full playable renditions.
+            // Fall back to the highest-bandwidth non-I-frame variant, then the first one.
+            let best = pl
+                .variants
+                .iter()
+                .filter(|v| !v.is_i_frame && v.resolution.is_some())
+                .max_by_key(|v| v.bandwidth)
+                .or_else(|| pl.variants.iter().filter(|v| !v.is_i_frame).max_by_key(|v| v.bandwidth))
+                .unwrap_or(&pl.variants[0]);
+            info!(
+                "Selected variant: bandwidth={}, resolution={:?}, video={:?}",
+                best.bandwidth, best.resolution, best.video
+            );
+            media_url = media_url.join(&best.uri)?;
             info!("media url: {media_url}");
             let resp = client.retryable(media_url.as_str()).await?;
             let bs = resp.bytes().await?;


### PR DESCRIPTION
## 问题

HLS 下载器固定取 master playlist 里的第一个变体：

```rust
media_url = media_url.join(&pl.variants[0].uri)?;
```

第一个变体不一定是最高画质。以 Twitch 为例，它会把各档转码清晰度（720p、480p 等）排在源流前面，所以录制经常得到比实际可用画质更低的转码流。这正是 #1611 提出的诉求。

## 改动

选取带有 `RESOLUTION`、且码率（bandwidth）最高的变体，同时跳过 `EXT-X-I-FRAME-STREAM-INF`（trick-play）条目（m3u8-rs 用 `is_i_frame` 标记这类条目）。如果没有任何变体带分辨率，则回退到码率最高的非 I-frame 变体，最后回退到第一个变体，保证在异常 playlist 下行为不会比原来更差。

```rust
let best = pl.variants.iter()
    .filter(|v| !v.is_i_frame && v.resolution.is_some())
    .max_by_key(|v| v.bandwidth)
    .or_else(|| pl.variants.iter().filter(|v| !v.is_i_frame).max_by_key(|v| v.bandwidth))
    .unwrap_or(&pl.variants[0]);
```

选中的变体会在 info 级别打印日志，方便排查画质问题。

## 说明

- 对所有 HLS 源都生效，不只是 Twitch。
- `cargo check -p biliup` 通过。按码率选流的逻辑在我自己的部署里跑了几个月，体感是抽样看的视频基本都变清晰了；这里额外加了 `is_i_frame` 过滤，用于处理包含 trick-play 流的 playlist。

Closes #1611
