### PR TITLE
fix(upload): include lock file path in rate-limit lock error message

### DIFF
--- a/crates/biliup-cli/src/upload_lock.rs
+++ b/crates/biliup-cli/src/upload_lock.rs
@@ -6,7 +6,7 @@
 
 use std::fs;
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 use tracing::{info, warn};
 
@@ -100,6 +100,11 @@ impl UploadLock {
     pub fn is_locked(&self) -> bool {
         self.lock_path.exists()
     }
+
+    /// 获取锁文件路径（用于提示用户手动清理残留锁文件）
+    pub fn path(&self) -> &Path {
+        &self.lock_path
+    }
 }
 
 impl Drop for UploadLock {
@@ -130,5 +135,13 @@ mod tests {
         assert!(lock2.try_acquire().unwrap());
 
         lock2.release().unwrap();
+    }
+
+    #[test]
+    fn test_lock_path() {
+        let lock = UploadLock::new("test_account").unwrap();
+
+        let path_str = lock.path().to_string_lossy().to_string();
+        assert!(path_str.ends_with("biliup_upload_test_account.lock"));
     }
 }

--- a/crates/biliup-cli/src/uploader.rs
+++ b/crates/biliup-cli/src/uploader.rs
@@ -474,8 +474,11 @@ pub async fn upload(
             let lock = upload_lock.lock().unwrap();
             if lock.is_locked() {
                 return Err(AppError::Custom(format!(
-                    "另一个使用该账号 ({}) 的上传进程正在等待限流恢复，请稍后重试",
-                    credential_id
+                    "另一个使用该账号 ({}) 的上传进程正在等待限流恢复，请稍后重试。\n\
+                     如果确认当前没有其他上传进程在运行，可能是上次异常退出残留的锁文件，\n\
+                     可手动删除以下文件后重试：\n  {}",
+                    credential_id,
+                    lock.path().display()
                 ))
                 .into());
             }


### PR DESCRIPTION
## 背景

关联 #1593。

当上传进程被 kill 或崩溃后，账号级上传锁文件（文件锁，位于 `<data_local_dir>/biliup/locks/`）会残留。之后同账号的上传在开始前的预检查发现锁文件存在就直接报错退出。但原报错信息没有告诉用户锁文件在哪里、如何处理，用户只能盲目等待（#1593 中的讨论也是卡在这里）。

## 改动

- `crates/biliup-cli/src/upload_lock.rs`
  - 新增 `UploadLock::path()` 访问器，暴露锁文件路径
  - 新增单元测试 `test_lock_path`
- `crates/biliup-cli/src/uploader.rs`
  - 锁冲突报错信息中增加锁文件完整路径，并提示：若确认无其他上传进程在运行，可能是上次异常退出残留的锁文件，可手动删除后重试

## 报错信息对比

之前：

    Error: 另一个使用该账号 (xxx) 的上传进程正在等待限流恢复，请稍后重试
    ╰╴at crates/biliup-cli/src/uploader.rs:479:18

现在：

    Error: 另一个使用该账号 (xxx) 的上传进程正在等待限流恢复，请稍后重试。
           如果确认当前没有其他上传进程在运行，可能是上次异常退出残留的锁文件，
           可手动删除以下文件后重试：
             /home/user/.local/share/biliup/locks/biliup_upload_xxx.lock
    ╰╴at crates/biliup-cli/src/uploader.rs:476:18

## 验证

- `cargo check -p biliup-cli` 通过
- `cargo test -p biliup-cli upload_lock` 2/2 通过

## 后续可改进（不在本次范围，建议另开 issue）

- `is_locked()` 预检查只判断文件是否存在，不判断 30 分钟过期（过期逻辑只在 `try_acquire()` 中），僵尸锁会一直挡住新上传；可考虑在预检查中同样做过期清理，或提供 `--force` 参数跳过检查
