### PR TITLE
fix(douyin): 下播后回放房间仍被误判为直播中

### DIFF
--- a/crates/biliup/src/downloader/live/douyin.rs
+++ b/crates/biliup/src/downloader/live/douyin.rs
@@ -358,6 +358,13 @@ impl<'a> DouyinLive<'a> {
         if room_info.get("status").and_then(Value::as_i64) != Some(2) {
             return Ok(None);
         }
+        // 下播后抖音会在回放房间写入 finish_time（结束时间戳），且 reflow 回放流
+        // 的 URL 携带 rtm_expr_tag=reflow_room_info 标记，二者均表明直播已结束。
+        // 此时接口仍可能返回 status=2 与可拉取的回放流，需在此判定为未开播，
+        // 避免 monitor 循环误判"直播中"并反复录制垫片流。
+        if room_info.get("finish_time").and_then(Value::as_i64).unwrap_or(0) > 0 {
+            return Ok(None);
+        }
         self.room_id = room_info
             .get("id_str")
             .and_then(Value::as_str)
@@ -439,6 +446,8 @@ impl<'a> DouyinLive<'a> {
             .and_then(Value::as_str)
             .filter(|url| !url.is_empty())
             .map(|url| url.replace("http://", "https://"))
+            // 回放流 URL 携带 reflow 标记，直播已结束，拒绝作为直播流返回
+            .filter(|url| !url.contains("rtm_expr_tag=reflow_room_info"))
             .ok_or_else(|| LiveError::custom("抖音可用直播流为空"))
     }
 


### PR DESCRIPTION
## 问题

关联 issue: #1532

抖音主播下播后：
- 直播间短链跳转到 `webcast.amemv.com/douyin/webcast/reflow/...`（回放页）
- H5 回放接口对已下播房间仍返回 `status = 2`（直播中）和可拉取的回放流
- monitor 每 30 秒误判"开播"，反复拉取回放垫片流（几秒~几十秒的小分段，常被过滤阈值删除），WebUI 主界面持续显示"直播中"

实测接口返回（下播 30 秒后）：
```json
{
  "data": {
    "room": {
      "status": 2,
      "finish_time": 1787737453,   // 已写入结束时间
      "stream_url": { ... }         // 仍返回可拉取的流，URL 带 rtm_expr_tag=reflow_room_info
    }
  }
}
```

## 修复

两道独立防线，任一命中即判定未开播：

1. **`get_room_info`**：`finish_time > 0`（抖音已写入直播结束时间戳）→ 判定未开播
2. **`select_stream_url`**：流 URL 含 `rtm_expr_tag=reflow_room_info`（回放流标记）→ 拒绝作为直播流返回，兜底防误判

## 验证

同一个已下播的抖音直播间：

- 修复前（v1.2.2 镜像）：每 30 秒一次 `room: is live -> 开播了`，反复拉流产出 4MB 垫片分段后被 `filtering_threshold` 删除
- 修复后（本地构建镜像）：监测 3 轮以上 **0 次误判**，主播状态保持 `Idle`，无文件产出、无无效拉流