### PR TITLE
fix(downloader): 纯视频流分段时避免序列头 expect 导致的 panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
  "clap",
  "cookie",
  "futures",
+ "http",
  "libsm",
  "m3u8-rs",
  "md-5",

--- a/crates/biliup/Cargo.toml
+++ b/crates/biliup/Cargo.toml
@@ -45,6 +45,7 @@ libsm = "0.6.0"
 [dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter"] }  # 添加特性（特性是累加的）  }
 tempfile = "3.14"
+http = "1"
 
 [features]
 cli = ["clap"]

--- a/crates/biliup/src/downloader/httpflv.rs
+++ b/crates/biliup/src/downloader/httpflv.rs
@@ -168,31 +168,40 @@ pub(crate) async fn parse_flv(
                     segment.set_start_time(Duration::from_millis(timestamp));
                     segment.set_size_position(9 + 4);
 
-                    let (meta_header, meta_bytes, previous_meta_tag_size) =
-                        on_meta_data.as_ref().expect("on_meta_data does not exist");
+                    // 开启新分段时补齐已捕获的头部标签。这些头部并非所有直播流都具备
+                    // （例如纯视频流没有 AAC 序列头，部分流缺少 onMetaData 脚本标签），
+                    // 缺失时跳过并告警，而不是像原先那样直接 expect/panic 中断录制。
                     // onMetaData
-                    flv_tags_cache.push((
-                        *meta_header,
-                        meta_bytes.clone(),
-                        previous_meta_tag_size.clone(),
-                    ));
+                    if let Some((meta_header, meta_bytes, previous_meta_tag_size)) =
+                        on_meta_data.as_ref()
+                    {
+                        flv_tags_cache.push((
+                            *meta_header,
+                            meta_bytes.clone(),
+                            previous_meta_tag_size.clone(),
+                        ));
+                    } else {
+                        warn!("onMetaData not found before segmenting; new segment will omit it.");
+                    }
                     // AACSequenceHeader
-                    let aac_sequence_header = aac_sequence_header
-                        .as_ref()
-                        .expect("aac_sequence_header does not exist");
-                    flv_tags_cache.push((
-                        aac_sequence_header.0,
-                        aac_sequence_header.1.clone(),
-                        aac_sequence_header.2.clone(),
-                    ));
+                    if let Some((aac_header, aac_bytes, aac_prev_tag_size)) =
+                        aac_sequence_header.as_ref()
+                    {
+                        flv_tags_cache.push((
+                            *aac_header,
+                            aac_bytes.clone(),
+                            aac_prev_tag_size.clone(),
+                        ));
+                    }
                     if !create_new {
                         // H264SequenceHeader
-                        flv_tags_cache.push(
-                            h264_sequence_header
-                                .as_ref()
-                                .expect("h264_sequence_header does not exist")
-                                .clone(),
-                        );
+                        if let Some(h264_header) = h264_sequence_header.as_ref() {
+                            flv_tags_cache.push(h264_header.clone());
+                        } else {
+                            warn!(
+                                "h264_sequence_header not found before segmenting; new segment may be unplayable."
+                            );
+                        }
                     }
                     info!("{} splitting.{segment:?}", out.file.file_name);
                     out.create_new()?;
@@ -319,6 +328,58 @@ mod tests {
     fn it_works() -> Result<(), Box<dyn std::error::Error>> {
         // download(
         //     "test.flv")?;
+        Ok(())
+    }
+
+    /// 回归测试：纯视频流（没有任何音频标签）在首次分段时不应 panic。
+    ///
+    /// 该流只包含一个 onMetaData 脚本标签和一个 H264 序列头关键帧，`aac_sequence_header`
+    /// 全程为 `None`。修复前，分段重建逻辑会对 `aac_sequence_header` 执行
+    /// `expect("aac_sequence_header does not exist")` 而 panic，导致纯视频直播录制中断。
+    #[tokio::test]
+    async fn pure_video_stream_segments_without_panic() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::downloader::util::{LifecycleFile, Segmentable};
+
+        let mut data: Vec<u8> = Vec::new();
+        // parse_flv 起始会先读取 4 字节（上一个 tag 的大小），这里给占位。
+        data.extend_from_slice(&[0, 0, 0, 0]);
+
+        // Script 标签（onMetaData），其值为 Null（0x05）。
+        // 结构：0x02(字符串) + u16 长度(10) + "onMetaData" + 0x05(Null)
+        let script_body: [u8; 14] = [
+            0x02, 0x00, 0x0A, b'o', b'n', b'M', b'e', b't', b'a', b'D', b'a', b't', b'a', 0x05,
+        ];
+        // tag_header: type=18(script), data_size=14, timestamp=0, stream_id=0
+        data.extend_from_slice(&[
+            0x12, 0x00, 0x00, 0x0E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        data.extend_from_slice(&script_body);
+        data.extend_from_slice(&[0, 0, 0, 0]); // previous_tag_size
+
+        // Video 标签：关键帧 + H264 序列头（无音频）。
+        // body[0]=0x17 → frame_type=Key(1), codec_id=H264(7)
+        // 其后 4 字节：avc packet_type=0(SequenceHeader) + composition_time(i24)=0
+        let video_body: [u8; 5] = [0x17, 0x00, 0x00, 0x00, 0x00];
+        // tag_header: type=9(video), data_size=5, timestamp=0, stream_id=0
+        data.extend_from_slice(&[
+            0x09, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        data.extend_from_slice(&video_body);
+        data.extend_from_slice(&[0, 0, 0, 0]); // previous_tag_size
+
+        let http_resp = http::Response::builder().status(200).body(data)?;
+        let resp = reqwest::Response::from(http_resp);
+        let connection = super::Connection::new(resp);
+
+        let dir = tempfile::tempdir()?;
+        let file_stem = dir.path().join("pure_video_seg");
+        let file = LifecycleFile::new(file_stem.to_str().unwrap(), "flv");
+
+        // expected_size 设得极小，确保首个关键帧即触发分段，进入头部重建路径。
+        let segment = Segmentable::new(None, Some(1));
+
+        // 修复前：此调用会 panic（aac_sequence_header does not exist）。
+        super::parse_flv(connection, file, segment).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
## 问题

`crates/biliup/src/downloader/httpflv.rs` 的 FLV 录制在开启新分段（`segment.needed()`）时，会对三种序列头执行 `expect`：

- `on_meta_data.expect("on_meta_data does not exist")`
- `aac_sequence_header.expect("aac_sequence_header does not exist")`
- `h264_sequence_header.expect("h264_sequence_header does not exist")`

其中**纯视频流（没有音频轨道）**不存在 AAC 序列头，`aac_sequence_header` 全程为 `None`，因此在**首次分段时必然 panic**，导致长时间无人值守的录制任务中断。缺少 `onMetaData` 脚本标签的流同样会在 `on_meta_data` 处 panic。

## 改动

将分段重建处的三处 `expect` 改为 `if let Some(...)`：序列头存在则写入新分段，缺失时跳过并 `warn!` 记录，不再中断录制。对“正常含音视频”的流行为保持不变，仅在头部缺失时由“panic”变为“跳过并告警”。

## 测试

新增回归测试 `pure_video_stream_segments_without_panic`：构造一个仅含 `onMetaData` 脚本标签与 H264 序列头关键帧、**无任何音频标签**的 FLV 字节流，并将分段大小阈值设为极小以触发首次分段。

- 修复前（对 `aac_sequence_header` 使用 `expect`）：该测试 panic —— `aac_sequence_header does not exist`（已实测复现）。
- 修复后：`cargo test -p biliup` 全部 59 项通过。

本地验证环境：Windows + `stable-x86_64-pc-windows-gnu`；`cargo test -p biliup` 全绿，`cargo fmt -p biliup -- --check` 通过。
