### PR TITLE
fix(hls): 按 target_duration 轮询播放列表，处理 ENDLIST 并传播解析错误

### DIFF
--- a/crates/biliup/src/downloader/hls.rs
+++ b/crates/biliup/src/downloader/hls.rs
@@ -1,14 +1,30 @@
 use crate::downloader::error::{Error, Result};
 use crate::downloader::util::{LifecycleFile, Segmentable};
-use m3u8_rs::Playlist;
+use m3u8_rs::{MediaPlaylist, Playlist};
 
 use std::fs::File;
 use std::io::{BufWriter, Write};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
 use url::Url;
 
 use crate::client::StatelessClient;
+
+const MIN_PLAYLIST_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+fn parse_media_playlist(bytes: &[u8]) -> Result<MediaPlaylist> {
+    m3u8_rs::parse_media_playlist(bytes)
+        .map(|(_, playlist)| playlist)
+        .map_err(|error| Error::Custom(format!("Unable to parse media playlist content: {error}")))
+}
+
+fn playlist_poll_interval(playlist: &MediaPlaylist) -> Duration {
+    Duration::from_secs(playlist.target_duration).max(MIN_PLAYLIST_POLL_INTERVAL)
+}
+
+fn playlist_should_refresh(playlist: &MediaPlaylist) -> bool {
+    !playlist.end_list
+}
 
 pub async fn download(
     url: &str,
@@ -52,17 +68,7 @@ pub async fn download(
             info!("media url: {media_url}");
             let resp = client.retryable(media_url.as_str()).await?;
             let bs = resp.bytes().await?;
-            // println!("{:?}", bs);
-            match m3u8_rs::parse_media_playlist(&bs) {
-                Ok((_, pl)) => pl,
-                Err(e) => {
-                    let mut file = File::create("test.fmp4")?;
-                    file.write_all(&bs)?;
-                    return Err(Error::Custom(format!(
-                        "Unable to parse media playlist content: {e}"
-                    )));
-                }
-            }
+            parse_media_playlist(&bs)?
         }
         Ok((_i, Playlist::MediaPlaylist(pl))) => {
             info!("Media playlist:\n{:#?}", pl);
@@ -72,10 +78,10 @@ pub async fn download(
         Err(e) => return Err(Error::Custom(format!("Parsing playlist error: {e}"))),
     };
     let mut previous_last_segment = 0;
+    let mut last_playlist_load = Instant::now();
     loop {
         if pl.segments.is_empty() {
-            info!("Segments array is empty - stream finished");
-            break;
+            debug!("Segments array is empty - waiting for playlist update");
         }
         let mut seq = pl.media_sequence;
         for segment in &pl.segments {
@@ -106,11 +112,23 @@ pub async fn download(
             }
             seq += 1;
         }
+
+        if !playlist_should_refresh(&pl) {
+            info!("#EXT-X-ENDLIST received - stream finished");
+            break;
+        }
+
+        let poll_interval = playlist_poll_interval(&pl);
+        let refresh_delay = poll_interval.saturating_sub(last_playlist_load.elapsed());
+        if !refresh_delay.is_zero() {
+            debug!("Waiting {refresh_delay:?} before refreshing media playlist");
+            tokio::time::sleep(refresh_delay).await;
+        }
+
         let resp = client.retryable(media_url.as_str()).await?;
         let bs = resp.bytes().await?;
-        if let Ok((_, playlist)) = m3u8_rs::parse_media_playlist(&bs) {
-            pl = playlist;
-        }
+        pl = parse_media_playlist(&bs)?;
+        last_playlist_load = Instant::now();
     }
     info!("Done...");
     Ok(())
@@ -176,7 +194,10 @@ impl Drop for TsFile<'_> {
 
 #[cfg(test)]
 mod tests {
+    use super::{parse_media_playlist, playlist_poll_interval, playlist_should_refresh};
+    use m3u8_rs::MediaPlaylist;
     use reqwest::Url;
+    use std::time::Duration;
 
     #[test]
     fn test_url() -> Result<(), Box<dyn std::error::Error>> {
@@ -193,5 +214,48 @@ mod tests {
         // download(
         //     "test.ts")?;
         Ok(())
+    }
+
+    #[test]
+    fn playlist_poll_interval_uses_target_duration() {
+        let playlist = MediaPlaylist {
+            target_duration: 6,
+            ..MediaPlaylist::default()
+        };
+
+        assert_eq!(playlist_poll_interval(&playlist), Duration::from_secs(6));
+    }
+
+    #[test]
+    fn playlist_poll_interval_has_one_second_minimum() {
+        assert_eq!(
+            playlist_poll_interval(&MediaPlaylist::default()),
+            Duration::from_secs(1)
+        );
+    }
+
+    #[test]
+    fn parse_media_playlist_preserves_end_list() {
+        let playlist = parse_media_playlist(
+            b"#EXTM3U\n\
+              #EXT-X-TARGETDURATION:6\n\
+              #EXT-X-MEDIA-SEQUENCE:7\n\
+              #EXTINF:6.0,\n\
+              7.ts\n\
+              #EXT-X-ENDLIST\n",
+        )
+        .expect("valid media playlist should parse");
+
+        assert!(playlist.end_list);
+        assert!(!playlist_should_refresh(&playlist));
+        assert_eq!(playlist.segments.len(), 1);
+    }
+
+    #[test]
+    fn parse_media_playlist_returns_error_for_invalid_content() {
+        let error = parse_media_playlist(b"not a media playlist")
+            .expect_err("invalid media playlist should return an error");
+
+        assert!(error.to_string().contains("Unable to parse media playlist"));
     }
 }


### PR DESCRIPTION
## 问题

`crates/biliup/src/downloader/hls.rs` 的下载主循环存在三个相互放大的缺陷：

- **无间隔忙轮询**：处理完当前播放列表的分片后立即重新拉取 m3u8，两次拉取之间没有任何等待。直播场景下播放列表通常数秒才更新一次，该循环会以最大速率连续请求源站，浪费 CPU/带宽，且容易触发风控封禁。
- **不检查 `#EXT-X-ENDLIST`**：流正常结束后，除非分片列表恰好变空，否则循环永不退出。
- **刷新时解析错误被静默吞掉**：`if let Ok((_, playlist)) = ...` 失败时保留陈旧播放列表，叠加无间隔轮询即退化为无限忙循环。

此外，初始播放列表为空（开播初期常见）会被误判为“流已结束”而直接退出，留下空文件。

## 改动

- 依据 `#EXT-X-TARGETDURATION` 节流：每次刷新前等待 `target_duration`（扣除本轮处理已耗时），对非法的 0 值设 1 秒下限。
- 每轮消费完分片后检查 `end_list`：先写入最终播放列表中的新分片，再干净退出。
- 刷新时的解析失败改为显式返回错误；初始解析路径复用同一辅助函数，顺带移除了向当前目录写 `test.fmp4` 的调试残留。
- 空分片列表不再视为流结束，改为按上述节奏继续轮询等待更新。

对“正常直播流”的行为保持不变，仅从“最大速率轰炸源站 + 永不退出”变为“按目标时长轮询 + 流结束即收尾”。

## 测试

新增 4 项回归测试：轮询间隔取自 `target_duration`、1 秒下限、`ENDLIST` 解析保留、非法内容返回显式错误。

另用本地脚本化 HTTP 服务器模拟直播 HLS 源做了行为级验证（验证用例未提交）：

- 播放列表恰好被请求 3 次（初始 + 2 次刷新），刷新间隔均 ≥ 1 秒 —— 修复前同场景为无间隔连续请求（已实测复现）；
- 带 `ENDLIST` 的最终播放列表中的新分片先落盘再退出，输出字节完整；
- 刷新返回非法内容时立即以 `Unable to parse media playlist` 中止；
- 空播放列表继续轮询，分片出现后正常下载。

本地验证环境：Windows + `stable-x86_64-pc-windows-gnu`；`cargo test -p biliup` 全部 62 项通过，`cargo fmt --all -- --check` 与 `cargo clippy -p biliup --all-targets` 通过（仅存量警告）。