### PR TITLE
fix(webup): Data 声明 desc_v2 字段，避免提交时被 asdict 静默丢弃

### DIFF
--- a/biliup/plugins/bili_webup.py
+++ b/biliup/plugins/bili_webup.py
@@ -989,6 +989,7 @@ class Data:
     title: str = ''
     desc_format_id: int = 0
     desc: str = ''
+    desc_v2: list = field(default_factory=list)
     dynamic: str = ''
     subtitle: dict = field(init=False)
     tag: Union[list, str] = ''


### PR DESCRIPTION
## 问题

`biliup/plugins/bili_webup.py`（异步版上传插件）的上传流程会为稿件设置富文本简介：

```python
if self.credits:
    video.desc_v2 = self.creditsToDesc_v2()
else:
    video.desc_v2 = [{"raw_text": self.desc, "biz_id": "", "type": 1}]
```

但异步版的 `Data` dataclass **没有声明 `desc_v2` 字段**，上面的赋值只是创建了普通实例属性。而 `submit_web` / `submit_client` 用 `dataclasses.asdict(self.video)` 构造请求体，`asdict` 只序列化已声明的字段——**`desc_v2`（含 `@credit` 用户关联的富文本简介）在提交时被静默丢弃**，用户配置的 credits 完全不生效且无任何报错。

同步版 `bili_webup_sync.py` 的 `Data` 已正确声明 `desc_v2: list = field(default_factory=list)`，这是两份复制粘贴实现分叉出的单侧 bug。

## 改动

为异步版 `Data` 补上与同步版一致的字段声明（单行）：

```python
desc_v2: list = field(default_factory=list)
```

行为与同步版对齐：设置过 `desc_v2` 的稿件提交时正常携带；未设置时提交空列表，与同步版现有行为一致。

## 测试

用临时脚本模拟上传流程的赋值路径并检查 `asdict` 输出（脚本未提交）：

- 修复前：`asdict(video)` 的结果中**不含** `desc_v2` 键（已实测复现）；
- 修复后：`desc_v2` 存在且与赋值完全一致，默认值为 `[]`；`python -m py_compile` 通过。

本地验证环境：Windows + Python 3.12.10（venv 安装 aiohttp/requests/rsa 后导入真实模块验证）。
