### PR TITLE
fix(stream-gears): 登录函数释放 GIL 后再执行阻塞网络请求

### DIFF
--- a/crates/stream-gears/src/lib.rs
+++ b/crates/stream-gears/src/lib.rs
@@ -178,106 +178,127 @@ fn download_with_callback(
 }
 
 #[pyfunction]
-fn login_by_cookies(file: String, proxy: Option<String>) -> PyResult<bool> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let result = rt.block_on(async { login::login_by_cookies(&file, proxy.as_deref()).await });
-    match result {
-        Ok(_) => Ok(true),
-        Err(err) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
-            "{}",
-            err
-        ))),
-    }
-}
-
-#[pyfunction]
-fn send_sms(country_code: u32, phone: u64, proxy: Option<String>) -> PyResult<String> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let result =
-        rt.block_on(async { login::send_sms(country_code, phone, proxy.as_deref()).await });
-    match result {
-        Ok(res) => Ok(res.to_string()),
-        Err(err) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
-            "{}",
-            err
-        ))),
-    }
-}
-
-#[pyfunction]
-fn login_by_sms(code: u32, ret: String, proxy: Option<String>) -> PyResult<bool> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let result = rt.block_on(async {
-        login::login_by_sms(code, serde_json::from_str(&ret).unwrap(), proxy.as_deref()).await
-    });
-    match result {
-        Ok(_) => Ok(true),
-        Err(_) => Ok(false),
-    }
-}
-
-#[pyfunction]
-fn get_qrcode(proxy: Option<String>) -> PyResult<String> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let result = rt.block_on(async { login::get_qrcode(proxy.as_deref()).await });
-    match result {
-        Ok(res) => Ok(res.to_string()),
-        Err(err) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
-            "{}",
-            err
-        ))),
-    }
-}
-
-#[pyfunction]
-fn login_by_qrcode(ret: String, proxy: Option<String>) -> PyResult<String> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(async {
-        let info = Credential::new(proxy.as_deref())
-            .login_by_qrcode(serde_json::from_str(&ret).unwrap())
-            .await?;
-        let res = serde_json::to_string_pretty(&info).unwrap();
-        Ok::<_, biliup::error::Kind>(res)
+fn login_by_cookies(py: Python<'_>, file: String, proxy: Option<String>) -> PyResult<bool> {
+    py.detach(|| {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(async { login::login_by_cookies(&file, proxy.as_deref()).await });
+        match result {
+            Ok(_) => Ok(true),
+            Err(err) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "{}",
+                err
+            ))),
+        }
     })
-    .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(format!("{:#?}", err)))
+}
+
+#[pyfunction]
+fn send_sms(
+    py: Python<'_>,
+    country_code: u32,
+    phone: u64,
+    proxy: Option<String>,
+) -> PyResult<String> {
+    py.detach(|| {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result =
+            rt.block_on(async { login::send_sms(country_code, phone, proxy.as_deref()).await });
+        match result {
+            Ok(res) => Ok(res.to_string()),
+            Err(err) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "{}",
+                err
+            ))),
+        }
+    })
+}
+
+#[pyfunction]
+fn login_by_sms(py: Python<'_>, code: u32, ret: String, proxy: Option<String>) -> PyResult<bool> {
+    py.detach(|| {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(async {
+            login::login_by_sms(code, serde_json::from_str(&ret).unwrap(), proxy.as_deref()).await
+        });
+        match result {
+            Ok(_) => Ok(true),
+            Err(_) => Ok(false),
+        }
+    })
+}
+
+#[pyfunction]
+fn get_qrcode(py: Python<'_>, proxy: Option<String>) -> PyResult<String> {
+    py.detach(|| {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(async { login::get_qrcode(proxy.as_deref()).await });
+        match result {
+            Ok(res) => Ok(res.to_string()),
+            Err(err) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "{}",
+                err
+            ))),
+        }
+    })
+}
+
+#[pyfunction]
+fn login_by_qrcode(py: Python<'_>, ret: String, proxy: Option<String>) -> PyResult<String> {
+    py.detach(|| {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let info = Credential::new(proxy.as_deref())
+                .login_by_qrcode(serde_json::from_str(&ret).unwrap())
+                .await?;
+            let res = serde_json::to_string_pretty(&info).unwrap();
+            Ok::<_, biliup::error::Kind>(res)
+        })
+        .map_err(|err| pyo3::exceptions::PyRuntimeError::new_err(format!("{:#?}", err)))
+    })
 }
 
 #[pyfunction]
 fn login_by_web_cookies(
+    py: Python<'_>,
     sess_data: String,
     bili_jct: String,
     proxy: Option<String>,
 ) -> PyResult<bool> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let result = rt.block_on(async {
-        login::login_by_web_cookies(&sess_data, &bili_jct, proxy.as_deref()).await
-    });
-    match result {
-        Ok(_) => Ok(true),
-        Err(err) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
-            "{}",
-            err
-        ))),
-    }
+    py.detach(|| {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(async {
+            login::login_by_web_cookies(&sess_data, &bili_jct, proxy.as_deref()).await
+        });
+        match result {
+            Ok(_) => Ok(true),
+            Err(err) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "{}",
+                err
+            ))),
+        }
+    })
 }
 
 #[pyfunction]
 fn login_by_web_qrcode(
+    py: Python<'_>,
     sess_data: String,
     dede_user_id: String,
     proxy: Option<String>,
 ) -> PyResult<bool> {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    let result = rt.block_on(async {
-        login::login_by_web_qrcode(&sess_data, &dede_user_id, proxy.as_deref()).await
-    });
-    match result {
-        Ok(_) => Ok(true),
-        Err(err) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
-            "{}",
-            err
-        ))),
-    }
+    py.detach(|| {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(async {
+            login::login_by_web_qrcode(&sess_data, &dede_user_id, proxy.as_deref()).await
+        });
+        match result {
+            Ok(_) => Ok(true),
+            Err(err) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "{}",
+                err
+            ))),
+        }
+    })
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## 问题

`crates/stream-gears/src/lib.rs` 中 7 个登录相关的 `#[pyfunction]`（`login_by_cookies`、`send_sms`、`login_by_sms`、`get_qrcode`、`login_by_qrcode`、`login_by_web_cookies`、`login_by_web_qrcode`）都在**持有 GIL 的状态下**通过 `rt.block_on(...)` 执行阻塞网络请求。调用期间整个 Python 解释器的其他线程（事件循环、日志、回调等）全部冻结。

- `login_by_qrcode` 最为严重：底层实现是无上限的轮询循环（每秒 POST 一次直到扫码完成），意味着用户扫码期间解释器可能冻结数十秒到几分钟；
- 同文件中的 `download` / `upload` / `main_loop` 均已正确使用 `py.detach(...)` 先释放 GIL，登录函数是遗漏的一批；
- 实测复现时还观察到更隐蔽的死锁形态：若网络请求依赖本进程内其他 Python 线程提供的服务（如测试中的本地代理线程），该线程同样被 GIL 冻结无法响应，请求会一路阻塞到 reqwest 的 60 秒连接超时。

## 改动

为上述 7 个函数补上 `py: Python<'_>` 参数，并将「创建 tokio runtime + `block_on`」整体包进 `py.detach(|| ...)`，与同文件 `download` / `upload` / `main_loop` 的既有模式对齐。`py` 参数由 PyO3 自动注入，**Python 侧函数签名不变**，纯行为修复。

## 测试

`cargo check -p stream-gears`、`cargo clippy -p stream-gears --all-targets`、`cargo fmt -- --check` 全部通过（Clippy 仅存量警告，无一涉及本文件）。

另用 maturin 构建真实扩展模块做了修复前后行为对比（临时脚本未提交）：本地慢速代理制造约 4 秒的真实阻塞网络请求，同时另一 Python 线程每 50ms 记录一次心跳：

| 指标 | 修复前 | 修复后 |
| --- | --- | --- |
| 调用期间心跳次数 | 1 | 80 |
| 最大心跳间隔 | 60.06s（≈ 整个调用时长） | 0.05s（正常节拍） |
| 调用耗时 | 60s（代理线程被冻结，撞连接超时） | 4s（代理线程正常响应） |

本地验证环境：Windows + `stable-x86_64-pc-windows-gnu` + Python 3.12.10（maturin 1.14.1 构建 abi3 wheel 后导入实测）。
