### PR TITLE
fix(server): 会话 Cookie 不再强制 Secure，修复 HTTP 远程访问登录后无法保持登录态

### DIFF
--- a/crates/biliup-cli/src/cli.rs
+++ b/crates/biliup-cli/src/cli.rs
@@ -170,6 +170,11 @@ pub enum Commands {
         #[arg(long, default_value = "false")]
         auth: bool,
 
+        /// 为会话 Cookie 附加 Secure 属性。仅当通过 HTTPS 反向代理访问 Web UI 时开启；
+        /// 直接通过 HTTP 远程访问时开启会导致浏览器丢弃登录态
+        #[arg(long, default_value = "false")]
+        secure_session_cookie: bool,
+
         /// 使用 biliup 1.0.7 风格配置文件启动录制
         #[arg(short, long, value_name = "FILE")]
         config: Option<PathBuf>,
@@ -228,7 +233,12 @@ mod tests {
         assert_eq!(cli.user_cookie, Path::new("cookies.json"));
         assert!(matches!(
             cli.command,
-            Commands::Server { ref bind, auth: false, .. } if bind == "127.0.0.1"
+            Commands::Server {
+                ref bind,
+                auth: false,
+                secure_session_cookie: false,
+                ..
+            } if bind == "127.0.0.1"
         ));
     }
 

--- a/crates/biliup-cli/src/lib.rs
+++ b/crates/biliup-cli/src/lib.rs
@@ -38,6 +38,7 @@ pub async fn run(
     run_with_cookie(
         addr,
         auth,
+        false,
         log_handle,
         config_path,
         PathBuf::from("cookies.json"),
@@ -48,6 +49,7 @@ pub async fn run(
 pub async fn run_with_cookie(
     addr: (&str, u16),
     auth: bool,
+    secure_session_cookie: bool,
     log_handle: LogHandle,
     config_path: Option<PathBuf>,
     user_cookie: PathBuf,
@@ -111,7 +113,7 @@ pub async fn run_with_cookie(
     }
 
     tracing::info!("migrations successfully ran, initializing axum server...");
-    ApplicationController::serve(&addr, auth, service_register)
+    ApplicationController::serve(&addr, auth, secure_session_cookie, service_register)
         .await
         .attach("could not initialize application routes")?;
     Ok(())

--- a/crates/biliup-cli/src/main.rs
+++ b/crates/biliup-cli/src/main.rs
@@ -154,11 +154,13 @@ async fn main() -> AppResult<()> {
             bind,
             port,
             auth,
+            secure_session_cookie,
             config,
         } => {
             biliup_cli::run_with_cookie(
                 (&bind, port),
                 auth,
+                secure_session_cookie,
                 console_reload_handle,
                 config,
                 user_cookie,

--- a/crates/biliup-cli/src/server/app.rs
+++ b/crates/biliup-cli/src/server/app.rs
@@ -28,6 +28,7 @@ impl ApplicationController {
     pub async fn serve(
         addr: &SocketAddr,
         enable_login_guard: bool,
+        secure_session_cookie: bool,
         service_register: ServiceRegister,
     ) -> AppResult<()> {
         // 会话层配置
@@ -50,10 +51,13 @@ impl ApplicationController {
 
         // 配置会话管理层
         let session_layer = SessionManagerLayer::new(session_store)
-            // Loopback development uses plain HTTP.  A non-loopback bind is
-            // expected to sit behind TLS, so never send its session cookie over
-            // an insecure browser connection.
-            .with_secure(!addr.ip().is_loopback())
+            // The server itself only speaks plain HTTP, and browsers refuse to
+            // store `Secure` cookies delivered over insecure remote origins, so
+            // a forced `Secure` attribute on non-loopback binds silently broke
+            // every direct-HTTP login. Default to a non-`Secure` cookie and let
+            // deployments behind an HTTPS reverse proxy opt in explicitly via
+            // `--secure-session-cookie`.
+            .with_secure(secure_session_cookie)
             .with_name("biliup.sid")
             .with_expiry(Expiry::OnInactivity(Duration::days(7)));
         // .with_signed(key);
@@ -167,11 +171,12 @@ async fn shutdown_signal(
 #[cfg(test)]
 mod tests {
     use super::with_optional_auth;
+    use crate::server::api::auth;
     use crate::server::infrastructure::connection_pool::ConnectionManager;
     use crate::server::infrastructure::users::Backend;
     use axum::Router;
     use axum::body::Body;
-    use axum::http::{Request, StatusCode};
+    use axum::http::{Request, StatusCode, header};
     use axum::routing::get;
     use axum_login::AuthManagerLayerBuilder;
     use tower::ServiceExt;
@@ -209,5 +214,61 @@ mod tests {
     async fn log_websocket_route_is_protected_when_auth_is_enabled() {
         assert_eq!(request_log_route(true).await, StatusCode::UNAUTHORIZED);
         assert_eq!(request_log_route(false).await, StatusCode::OK);
+    }
+
+    /// Issues a real login-session `Set-Cookie` through the register endpoint
+    /// and returns the raw header value.
+    async fn session_set_cookie_header(secure_session_cookie: bool) -> String {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("data.sqlite3");
+        let pool = ConnectionManager::new_pool(db.to_str().unwrap())
+            .await
+            .unwrap();
+        let session_store = SqliteStore::new(pool.clone());
+        session_store.migrate().await.unwrap();
+        let auth_layer = AuthManagerLayerBuilder::new(
+            Backend::new(pool),
+            SessionManagerLayer::new(session_store).with_secure(secure_session_cookie),
+        )
+        .build();
+        let app = auth::router().layer(auth_layer);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/users/register")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{"username":"biliup","password":"test-password"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        response
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("login must establish a session cookie")
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    /// Direct HTTP access (the default deployment) must not mark the session
+    /// cookie `Secure`, otherwise browsers on remote non-HTTPS origins drop it
+    /// and every login silently bounces back to the login page.
+    #[tokio::test]
+    async fn session_cookie_secure_attribute_follows_configuration() {
+        assert!(
+            !session_set_cookie_header(false).await.contains("Secure"),
+            "default session cookie must work over plain HTTP"
+        );
+        assert!(
+            session_set_cookie_header(true).await.contains("Secure"),
+            "--secure-session-cookie must mark the cookie Secure"
+        );
     }
 }

--- a/crates/stream-gears/src/server.rs
+++ b/crates/stream-gears/src/server.rs
@@ -284,11 +284,13 @@ pub(crate) async fn _main(args: &[String]) -> AppResult<()> {
             bind,
             port,
             auth,
+            secure_session_cookie,
             config,
         } => {
             biliup_cli::run_with_cookie(
                 (&bind, port),
                 auth,
+                secure_session_cookie,
                 reload_handle,
                 config,
                 cli.user_cookie,


### PR DESCRIPTION
## 问题

用户反馈：WebUI 登录后「后端日志反复显示 Successfully logged in，但前端不跳转」。

排查后确认完整因果链：

1. `crates/biliup-cli/src/server/app.rs` 原实现将会话 Cookie 的 `Secure` 属性与绑定地址绑定：`.with_secure(!addr.ip().is_loopback())`，即 `-b 0.0.0.0` 等非回环绑定强制 `Secure`；
2. 而 biliup server 本身**只提供 HTTP**。用户通过 `http://<ip>:19159` 远程访问时，浏览器规范禁止在非安全上下文存储 `Secure` Cookie —— 登录响应 200，但 `Set-Cookie` 被浏览器静默丢弃；
3. 前端登录成功后执行 `window.location.assign('/')` 正常跳转，但 SPA 随后的所有 API 请求都因无会话而 401，`app/lib/api-streamer.ts` 的 401 统一处理又把页面弹回 `/login`；
4. 用户看到的就是「登录成功提示一闪、留在登录页」，于是反复重试——与后端日志中连续多次 `Web login attempt` / `Successfully logged in` 完全吻合。

该问题在本地无法复现（浏览器将 `localhost` 视为安全上下文，`Secure` Cookie 照常存储），只在**非回环绑定 + HTTP 远程访问**（该工具最常见的部署方式，README 快速开始即如此）时出现，登录功能完全不可用且无任何报错。

## 改动

- 会话 Cookie 的 `Secure` 属性不再由绑定地址推断，改为新增 CLI 参数 `--secure-session-cookie` 显式控制，默认关闭：
  - 默认（直连 HTTP 部署）：Cookie 不带 `Secure`，远程登录恢复正常；`HttpOnly`、`SameSite=Strict` 等其余属性保持不变；
  - 通过 HTTPS 反向代理部署的用户：显式加 `--secure-session-cookie` 恢复强制加密传输语义；
- 参数经 `cli.rs` → `main.rs` / `stream-gears/server.rs` → `run_with_cookie` → `ApplicationController::serve` 完整穿透，两个入口（独立二进制与 PyO3 `main_loop`）行为一致。

## 测试

新增 2 项回归测试：

- `session_cookie_secure_attribute_follows_configuration`：经真实注册接口产生会话 `Set-Cookie`，断言 `Secure` 属性完全跟随配置开关（默认无、开启后有）；
- CLI 默认值测试扩展：断言 `secure_session_cookie` 默认为 `false`。

端到端验证（本地构建修复前后两个二进制，同一数据库实测）：

| 场景 | 登录响应 Set-Cookie |
| --- | --- |
| 修复前 + `-b 0.0.0.0 --auth` | `biliup.sid=...; HttpOnly; SameSite=Strict; **Secure**`（浏览器远程 HTTP 下丢弃，复现故障） |
| 修复后 + `-b 0.0.0.0 --auth`（默认） | `biliup.sid=...; HttpOnly; SameSite=Strict`（无 `Secure`） |
| 修复后 + `--secure-session-cookie` | 带 `Secure` |

并验证修复后完整会话闭环：携带 Cookie 访问受保护接口返回 200，无 Cookie 返回 401。

`cargo test -p biliup-cli`：88 通过、1 失败——失败项 `static_files_are_limited_to_media_and_known_logs` 为 Windows 平台存量问题（`canonicalize()` 返回 `\\?\` UNC 前缀路径），已确认在未修改的 master 上同样失败，与本改动无关。`cargo fmt --check` 与 `cargo clippy` 通过（仅存量警告，无一涉及本次修改的文件）。

本地验证环境：Windows + `stable-x86_64-pc-windows-gnu`。
