### PR TITLE
feat(sync): 恢复边录边传（sync-downloader）流式上传管线

### DIFF
--- a/crates/biliup-cli/src/server/common/download.rs
+++ b/crates/biliup-cli/src/server/common/download.rs
@@ -1,4 +1,5 @@
 use crate::server::common::recording_policy;
+use crate::server::common::sync::SyncSession;
 use crate::server::common::upload::UploaderMessage;
 use crate::server::common::util::FileValidator;
 use crate::server::core::downloader::cover_downloader;
@@ -15,7 +16,7 @@ use biliup::downloader::live::{LivePlugin, LiveStatus, LiveStream};
 use error_stack::ResultExt;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::Notify;
+use tokio::sync::{Mutex, Notify};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
@@ -118,14 +119,18 @@ pub struct DownloadTask {
     token: CancellationToken,
     done_notify: Notify,
     downloader: DownloaderRuntime,
+    sync_session: Option<Arc<Mutex<SyncSession>>>,
 }
 
 impl DownloadTask {
     pub fn new(downloader: DownloaderRuntime) -> Self {
+        let sync_session = matches!(&downloader, DownloaderRuntime::Sync(_))
+            .then(|| Arc::new(Mutex::new(SyncSession::default())));
         Self {
             token: CancellationToken::new(),
             done_notify: Notify::new(),
             downloader,
+            sync_session,
         }
     }
 
@@ -162,6 +167,12 @@ impl DownloadTask {
 
         // 初始化组件
         let mut processor = SegmentEventProcessor::new(sender, ctx.clone());
+        // 边录边传：记录已确认分 P 数，只有真正推进投稿才算“有进展”。
+        // 否则持续性错误（如 cookie 失效、preupload 被拒）会在直播中零延迟热循环。
+        let mut last_committed = match &self.sync_session {
+            Some(session) => session.lock().await.committed_parts(),
+            None => 0,
+        };
         let result = loop {
             // 创建守卫确保清理
             // 创建事件处理器
@@ -186,8 +197,24 @@ impl DownloadTask {
                         url = url,
                         "Stream is still live, preparing to retry. attempt: {}", retry_count
                     );
-                    // 成功下载后重置计数
-                    retry_count = 0;
+                    // 边录边传只有分 P 有实际推进才重置退避。管线的多数失败路径
+                    // （空流、分段过小）返回 Ok(StreamEnded)，不能以 Ok/Err 判断；
+                    // 否则拉流持续失败会零延迟重跑登录、preupload。
+                    // 非边录边传保持原行为（仍在直播即重置）。
+                    let progressed = match &self.sync_session {
+                        Some(session) => {
+                            let committed = session.lock().await.committed_parts();
+                            let progressed = committed > last_committed;
+                            last_committed = committed;
+                            progressed
+                        }
+                        None => true,
+                    };
+                    if progressed {
+                        retry_count = 0;
+                    } else {
+                        retry_count += 1;
+                    }
                 }
                 Ok(LiveStatus::Offline) => {
                     retry_count += 1;
@@ -266,6 +293,25 @@ impl DownloadTask {
     ) -> AppResult<DownloadStatus> {
         // 获取配置和主播信息
         let streamer = ctx.live_streamer();
+        let download_config = ctx.download_config(stream);
+        if let crate::server::core::downloader::DownloaderRuntime::Sync(sync) = &self.downloader {
+            info!(
+                page_url = streamer.url,
+                stream_url = download_config.url,
+                platform = stream.platform,
+                "开始边录边传，已解析流直链"
+            );
+            return crate::server::common::sync::run_sync_pipeline(
+                sync,
+                self.token.clone(),
+                &ctx,
+                download_config,
+                self.sync_session
+                    .clone()
+                    .expect("sync downloader must have a sync session"),
+            )
+            .await;
+        }
 
         // 执行下载
         // let hook = processor.create_hook(danmaku_client.clone());
@@ -294,7 +340,6 @@ impl DownloadTask {
             }
         };
 
-        let download_config = ctx.download_config(stream);
         info!(
             page_url = streamer.url,
             stream_url = download_config.url,
@@ -319,7 +364,14 @@ impl DownloadTask {
         // 如果底层下载函数不支持取消，这里不能真正中断正在进行的下载
         self.token.cancel();
         self.downloader.stop().await?;
-        self.done_notify.notified().await;
+        // 清理设总时限：取消已传导到录制/上传/投稿各阶段，正常应立即退出；
+        // 万一后台请求卡住，也不能让 stop 无限挂起拖住整个 worker。
+        if tokio::time::timeout(Duration::from_secs(30), self.done_notify.notified())
+            .await
+            .is_err()
+        {
+            warn!("等待下载任务退出超时（30 秒），继续关闭流程");
+        }
         Ok(())
     }
 }

--- a/crates/biliup-cli/src/server/common/mod.rs
+++ b/crates/biliup-cli/src/server/common/mod.rs
@@ -5,6 +5,8 @@ use std::str::FromStr;
 pub mod download;
 /// 录制准入策略
 pub mod recording_policy;
+/// 边录边传（ffmpeg stdout → 流式投稿）
+pub mod sync;
 /// 录制时间范围判定
 pub mod timerange;
 pub mod upload;

--- a/crates/biliup-cli/src/server/common/sync.rs
+++ b/crates/biliup-cli/src/server/common/sync.rs
@@ -1,0 +1,637 @@
+use crate::server::common::upload::{
+    UploadContext, aid_from_submit, build_studio, complete_byte_stream, edit_to_bilibili,
+    execute_postprocessor, initialize_upload_context, submit_to_bilibili, upload_byte_stream_parts,
+    upload_single_file,
+};
+use crate::server::common::util::Recorder;
+use crate::server::core::downloader::sync_downloader::{
+    PumpResult, SyncDownloader, align_file_size, pump_chunks,
+};
+use crate::server::core::downloader::{DownloadConfig, DownloadStatus};
+use crate::server::errors::{AppError, AppResult};
+use crate::server::infrastructure::context::{Context, Stage, WorkerStatus};
+use crate::server::infrastructure::models::upload_streamer::UploadStreamer;
+use biliup::bilibili::{BiliBili, Studio, Video};
+use biliup::uploader::line::UploadedStream;
+use bytes::Bytes;
+use error_stack::ResultExt;
+use futures::StreamExt;
+use std::collections::{BTreeMap, VecDeque};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+const MIN_MEDIA_BYTES: u64 = 100;
+const MAX_EMPTY_RETRIES: u32 = 5;
+const STREAM_QUEUE_CAPACITY: usize = 6;
+const MAX_UNCOMMITTED_SEGMENTS: usize = 2;
+
+#[derive(Debug, Clone)]
+struct SegmentFile {
+    path: PathBuf,
+    keep: bool,
+}
+
+#[derive(Default)]
+pub(crate) struct SyncSession {
+    studio: Option<Studio>,
+    videos: Vec<Video>,
+    files: Vec<SegmentFile>,
+    confirmed_parts: usize,
+    cleaned_parts: usize,
+    first_submit_uncertain: bool,
+    postprocess_paths: Vec<PathBuf>,
+}
+
+impl SyncSession {
+    pub(crate) fn committed_parts(&self) -> usize {
+        self.confirmed_parts
+    }
+}
+
+struct PendingSegment {
+    seq: u64,
+    file: SegmentFile,
+    pump: PumpResult,
+    upload: JoinHandle<AppResult<UploadedStream>>,
+}
+
+struct ReadySegment {
+    seq: u64,
+    file: SegmentFile,
+    video: Video,
+}
+
+pub(crate) async fn run_sync_pipeline(
+    downloader: &SyncDownloader,
+    token: CancellationToken,
+    ctx: &Context,
+    download_config: DownloadConfig,
+    session: Arc<Mutex<SyncSession>>,
+) -> AppResult<DownloadStatus> {
+    let Some(upload_config) = ctx.upload_config().clone() else {
+        return Err(AppError::Custom("边录边传需要先为主播设定上传模板".into()).into());
+    };
+    if upload_config.is_noop_uploader() {
+        return Err(AppError::Custom("边录边传不支持 Noop 上传器".into()).into());
+    }
+
+    ctx.change_status(Stage::Upload, WorkerStatus::Pending)
+        .await;
+    let result = run_inner(
+        downloader,
+        token,
+        ctx,
+        download_config,
+        &upload_config,
+        session,
+    )
+    .await;
+    ctx.change_status(Stage::Upload, WorkerStatus::Idle).await;
+    result
+}
+
+async fn run_inner(
+    downloader: &SyncDownloader,
+    token: CancellationToken,
+    ctx: &Context,
+    download_config: DownloadConfig,
+    upload_config: &UploadStreamer,
+    session: Arc<Mutex<SyncSession>>,
+) -> AppResult<DownloadStatus> {
+    let mut upload_ctx =
+        initialize_upload_context(&ctx.config(), ctx.stateless_client(), upload_config).await?;
+    upload_ctx.threads = 3;
+    let total_size = align_file_size(download_config.file_size);
+    info!(max_file_size_mb = total_size / 1024 / 1024, "启动边录边传");
+
+    let mut recorder = ctx.recorder(ctx.streamer_info().clone());
+    recorder.filename_prefix = upload_config.title.clone();
+    let prefix = download_config.recorder.generate_filename("mkv");
+    let save_dir = ctx.config().sync_save_dir.clone().map(PathBuf::from);
+    let mut pending = VecDeque::new();
+    let mut ready = BTreeMap::new();
+
+    // 上一轮若 edit 失败，先用同一份有序 videos 快照重试，不能先录新段。
+    commit_unconfirmed(
+        &session,
+        &upload_ctx.bilibili,
+        upload_config,
+        ctx.config().submit_api.as_deref(),
+        &recorder,
+    )
+    .await?;
+
+    let result = run_loop(
+        downloader,
+        &token,
+        ctx,
+        &download_config,
+        upload_config,
+        &upload_ctx,
+        &recorder,
+        &prefix,
+        save_dir.as_ref(),
+        total_size,
+        &session,
+        &mut pending,
+        &mut ready,
+    )
+    .await;
+
+    let _ = downloader.stop().await;
+    cleanup_pending(&mut pending, &mut ready).await;
+
+    if result.is_ok() && !token.is_cancelled() {
+        let paths = {
+            let mut state = session.lock().await;
+            std::mem::take(&mut state.postprocess_paths)
+        };
+        if !paths.is_empty() {
+            execute_postprocessor(paths, ctx).await?;
+        }
+    }
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_loop(
+    downloader: &SyncDownloader,
+    token: &CancellationToken,
+    ctx: &Context,
+    download_config: &DownloadConfig,
+    upload_config: &UploadStreamer,
+    upload_ctx: &UploadContext,
+    recorder: &Recorder,
+    prefix: &str,
+    save_dir: Option<&PathBuf>,
+    total_size: u64,
+    session: &Arc<Mutex<SyncSession>>,
+    pending: &mut VecDeque<PendingSegment>,
+    ready: &mut BTreeMap<u64, ReadySegment>,
+) -> AppResult<DownloadStatus> {
+    let mut empty_retries = 0u32;
+    let mut next_seq = session.lock().await.videos.len() as u64 + 1;
+
+    loop {
+        if token.is_cancelled() {
+            return Ok(DownloadStatus::StreamEnded);
+        }
+
+        collect_finished(pending, ready, upload_ctx, token).await?;
+        commit_ready(
+            ready,
+            session,
+            &upload_ctx.bilibili,
+            upload_config,
+            ctx.config().submit_api.as_deref(),
+            recorder,
+        )
+        .await?;
+
+        while pending.len() + ready.len() >= MAX_UNCOMMITTED_SEGMENTS {
+            let work = pending
+                .pop_front()
+                .ok_or_else(|| AppError::Custom("边录边传待提交队列状态错误".into()))?;
+            let segment = finish_pending(work, upload_ctx, token).await?;
+            ready.insert(segment.seq, segment);
+            commit_ready(
+                ready,
+                session,
+                &upload_ctx.bilibili,
+                upload_config,
+                ctx.config().submit_api.as_deref(),
+                recorder,
+            )
+            .await?;
+        }
+
+        let file_name = format!("{prefix}_{next_seq}.mkv");
+        let keep = save_dir.is_some();
+        let path = save_dir.map_or_else(
+            || {
+                std::env::temp_dir()
+                    .join("biliup-sync")
+                    .join(format!("worker-{}", ctx.worker_id()))
+                    .join(&file_name)
+            },
+            |dir| dir.join(&file_name),
+        );
+        info!(seq = next_seq, file_name, "准备边录边传分段");
+
+        let parcel = upload_ctx
+            .line
+            .pre_upload_stream(&upload_ctx.bilibili, &file_name, total_size)
+            .await
+            .change_context(AppError::Unknown)?;
+        let chunk_size = parcel.chunk_size();
+        if chunk_size == 0 {
+            return Err(AppError::Custom("preupload 未返回 chunk_size".into()).into());
+        }
+
+        let Some(segment) = downloader
+            .start_segment(download_config, total_size, token)
+            .await?
+        else {
+            empty_retries += 1;
+            warn!(empty_retries, "ffmpeg 没有输出数据，重试边录边传拉流");
+            if empty_retries >= MAX_EMPTY_RETRIES {
+                break;
+            }
+            tokio::select! {
+                _ = token.cancelled() => return Ok(DownloadStatus::StreamEnded),
+                _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
+            }
+            continue;
+        };
+        empty_retries = 0;
+
+        let (tx, rx) = async_channel::bounded::<Bytes>(STREAM_QUEUE_CAPACITY);
+        let segment_ctx = upload_ctx.clone();
+        let upload = tokio::spawn(async move {
+            let stream = rx.map(|chunk: Bytes| {
+                let len = chunk.len();
+                Ok((chunk, len))
+            });
+            upload_byte_stream_parts(&segment_ctx, parcel, stream).await
+        });
+        let pump = pump_chunks(
+            segment.stdout,
+            segment.peeked,
+            chunk_size,
+            total_size,
+            path.clone(),
+            tx,
+            token.clone(),
+        )
+        .await;
+        let _ = downloader.stop().await;
+        let pump = match pump {
+            Ok(pump) => pump,
+            Err(error) => {
+                upload.abort();
+                let _ = upload.await;
+                if !keep {
+                    let _ = tokio::fs::remove_file(&path).await;
+                }
+                return Err(error);
+            }
+        };
+        info!(
+            seq = next_seq,
+            actual_size = pump.actual_size,
+            streamed_size = pump.streamed_size,
+            stream_complete = pump.stream_complete,
+            "本段录制结束"
+        );
+
+        if pump.actual_size < MIN_MEDIA_BYTES {
+            upload.abort();
+            let _ = upload.await;
+            if !keep {
+                let _ = tokio::fs::remove_file(&path).await;
+            }
+            break;
+        }
+
+        pending.push_back(PendingSegment {
+            seq: next_seq,
+            file: SegmentFile { path, keep },
+            pump,
+            upload,
+        });
+        next_seq += 1;
+    }
+
+    while let Some(work) = pending.pop_front() {
+        let segment = finish_pending(work, upload_ctx, token).await?;
+        ready.insert(segment.seq, segment);
+        commit_ready(
+            ready,
+            session,
+            &upload_ctx.bilibili,
+            upload_config,
+            ctx.config().submit_api.as_deref(),
+            recorder,
+        )
+        .await?;
+    }
+    Ok(DownloadStatus::StreamEnded)
+}
+
+async fn collect_finished(
+    pending: &mut VecDeque<PendingSegment>,
+    ready: &mut BTreeMap<u64, ReadySegment>,
+    upload_ctx: &UploadContext,
+    token: &CancellationToken,
+) -> AppResult<()> {
+    let mut index = 0;
+    while index < pending.len() {
+        if pending[index].upload.is_finished() {
+            let work = pending.remove(index).expect("pending index must exist");
+            let segment = finish_pending(work, upload_ctx, token).await?;
+            ready.insert(segment.seq, segment);
+        } else {
+            index += 1;
+        }
+    }
+    Ok(())
+}
+
+async fn finish_pending(
+    mut work: PendingSegment,
+    upload_ctx: &UploadContext,
+    token: &CancellationToken,
+) -> AppResult<ReadySegment> {
+    let uploaded = tokio::select! {
+        _ = token.cancelled() => {
+            work.upload.abort();
+            let _ = work.upload.await;
+            return Err(AppError::Custom("边录边传上传已取消".into()).into());
+        }
+        result = &mut work.upload => result,
+    };
+
+    let video = if work.pump.stream_complete {
+        match uploaded {
+            Ok(Ok(uploaded))
+                if uploaded.uploaded_size() == uploaded.declared_size()
+                    && uploaded.uploaded_size() == work.pump.actual_size =>
+            {
+                match tokio::select! {
+                    _ = token.cancelled() => {
+                        return Err(AppError::Custom("边录边传 complete 已取消".into()).into());
+                    }
+                    result = complete_byte_stream(uploaded) => result,
+                } {
+                    Ok(video) => Some(video),
+                    Err(error) => {
+                        warn!(seq = work.seq, ?error, "UPOS complete 失败，按临时文件重传");
+                        None
+                    }
+                }
+            }
+            Ok(Ok(uploaded)) => {
+                warn!(
+                    seq = work.seq,
+                    uploaded_size = uploaded.uploaded_size(),
+                    actual_size = work.pump.actual_size,
+                    "UPOS 预传长度不一致，按临时文件重传"
+                );
+                None
+            }
+            Ok(Err(error)) => {
+                warn!(seq = work.seq, ?error, "UPOS 预传失败，按临时文件重传");
+                None
+            }
+            Err(error) => {
+                warn!(seq = work.seq, ?error, "UPOS 预传任务失败，按临时文件重传");
+                None
+            }
+        }
+    } else {
+        if let Ok(Err(error)) = uploaded {
+            warn!(seq = work.seq, ?error, "短流预传未完成，按实际长度重传");
+        }
+        None
+    };
+
+    let video = match video {
+        Some(video) => video,
+        None => {
+            tokio::select! {
+                _ = token.cancelled() => {
+                    return Err(AppError::Custom("边录边传文件回退上传已取消".into()).into());
+                }
+                result = upload_single_file(&work.file.path, upload_ctx) => result?,
+            }
+        }
+    };
+    Ok(ReadySegment {
+        seq: work.seq,
+        file: work.file,
+        video,
+    })
+}
+
+/// 只允许提交紧接在已入列分 P 之后的分段，晚完成的前序分段会把后序分段留在 `ready` 中。
+fn next_committable(
+    ready: &mut BTreeMap<u64, ReadySegment>,
+    committed_videos: usize,
+) -> Option<ReadySegment> {
+    ready.remove(&(committed_videos as u64 + 1))
+}
+
+async fn commit_ready(
+    ready: &mut BTreeMap<u64, ReadySegment>,
+    session: &Arc<Mutex<SyncSession>>,
+    bilibili: &BiliBili,
+    upload_config: &UploadStreamer,
+    submit_api: Option<&str>,
+    recorder: &Recorder,
+) -> AppResult<()> {
+    loop {
+        let committed = session.lock().await.videos.len();
+        let Some(segment) = next_committable(ready, committed) else {
+            break;
+        };
+        {
+            let mut state = session.lock().await;
+            state.videos.push(segment.video);
+            state.files.push(segment.file);
+        }
+        commit_unconfirmed(session, bilibili, upload_config, submit_api, recorder).await?;
+    }
+    Ok(())
+}
+
+async fn commit_unconfirmed(
+    session: &Arc<Mutex<SyncSession>>,
+    bilibili: &BiliBili,
+    upload_config: &UploadStreamer,
+    submit_api: Option<&str>,
+    recorder: &Recorder,
+) -> AppResult<()> {
+    let (temporary_files, committed) = {
+        let mut state = session.lock().await;
+        if state.confirmed_parts == state.videos.len() {
+            return Ok(());
+        }
+        if state.first_submit_uncertain {
+            return Err(AppError::Custom(
+                "首 P 投稿结果不确定，已停止自动重试以避免生成重复稿件".into(),
+            )
+            .into());
+        }
+
+        let videos = state.videos.clone();
+        let videos_len = state.videos.len();
+        if let Some(studio) = state.studio.as_mut() {
+            studio.videos = videos;
+            edit_to_bilibili(bilibili, studio, submit_api).await?;
+            let aid = studio.aid;
+            state.confirmed_parts = videos_len;
+            info!(parts = videos_len, aid, "边录边传追加分P成功");
+        } else {
+            let mut studio = build_studio(upload_config, bilibili, videos, recorder).await?;
+            let ret = match submit_to_bilibili(bilibili, &studio, submit_api).await {
+                Ok(ret) => ret,
+                Err(error) => {
+                    state.first_submit_uncertain = true;
+                    return Err(error);
+                }
+            };
+            // 投稿已成功但解析不出 aid 时同样标记不确定：
+            // 此时服务端大概率已建稿，再自动重投会产生重复稿件。
+            let aid = match aid_from_submit(&ret) {
+                Ok(aid) => aid,
+                Err(error) => {
+                    state.first_submit_uncertain = true;
+                    return Err(error);
+                }
+            };
+            studio.aid = Some(aid);
+            state.confirmed_parts = videos_len;
+            state.studio = Some(studio);
+            info!(aid, "边录边传首P投稿成功");
+        }
+
+        let mut temporary_files = Vec::new();
+        while state.cleaned_parts < state.confirmed_parts {
+            let file = state.files[state.cleaned_parts].clone();
+            if file.keep {
+                state.postprocess_paths.push(file.path);
+            } else {
+                temporary_files.push(file.path);
+            }
+            state.cleaned_parts += 1;
+        }
+        (temporary_files, state.confirmed_parts)
+    };
+
+    for path in temporary_files {
+        if let Err(error) = tokio::fs::remove_file(&path).await {
+            warn!(?path, ?error, "删除边录边传临时文件失败");
+        }
+    }
+    info!(committed, "边录边传分P状态已确认");
+    Ok(())
+}
+
+async fn cleanup_pending(
+    pending: &mut VecDeque<PendingSegment>,
+    ready: &mut BTreeMap<u64, ReadySegment>,
+) {
+    while let Some(work) = pending.pop_front() {
+        work.upload.abort();
+        let _ = work.upload.await;
+        if !work.file.keep {
+            let _ = tokio::fs::remove_file(work.file.path).await;
+        }
+    }
+    for (_, segment) in std::mem::take(ready) {
+        if !segment.file.keep {
+            let _ = tokio::fs::remove_file(segment.file.path).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn segment(seq: u64) -> ReadySegment {
+        ReadySegment {
+            seq,
+            file: SegmentFile {
+                path: PathBuf::from(format!("seg-{seq}.mkv")),
+                keep: true,
+            },
+            video: Video::new(&format!("seg-{seq}")),
+        }
+    }
+
+    fn dummy_bili() -> BiliBili {
+        BiliBili {
+            client: reqwest::Client::new(),
+            login_info: serde_json::from_value(serde_json::json!({
+                "cookie_info": {},
+                "sso": [],
+                "token_info": {
+                    "access_token": "",
+                    "expires_in": 0,
+                    "mid": 0,
+                    "refresh_token": ""
+                },
+                "platform": null
+            }))
+            .expect("构造测试 LoginInfo"),
+        }
+    }
+
+    fn dummy_upload_config() -> UploadStreamer {
+        serde_json::from_value(serde_json::json!({
+            "id": 0,
+            "template_name": "test",
+            "tags": []
+        }))
+        .expect("构造测试 UploadStreamer")
+    }
+
+    #[test]
+    fn later_segment_finishing_first_waits_for_recording_order() {
+        let mut ready = BTreeMap::new();
+        ready.insert(2, segment(2));
+        assert!(
+            next_committable(&mut ready, 0).is_none(),
+            "P2 先上传完也不能先投稿"
+        );
+
+        ready.insert(1, segment(1));
+        assert_eq!(next_committable(&mut ready, 0).unwrap().seq, 1);
+        assert_eq!(next_committable(&mut ready, 1).unwrap().seq, 2);
+        assert!(next_committable(&mut ready, 2).is_none());
+    }
+
+    #[tokio::test]
+    async fn confirmed_session_skips_resubmission_across_reconnects() {
+        // 重连后 session 里已确认的分 P 不应触发任何网络提交（否则早就 panic 在请求上）
+        let session = Arc::new(Mutex::new(SyncSession {
+            videos: vec![Video::new("p1")],
+            confirmed_parts: 1,
+            cleaned_parts: 1,
+            ..Default::default()
+        }));
+        commit_unconfirmed(
+            &session,
+            &dummy_bili(),
+            &dummy_upload_config(),
+            None,
+            &Recorder::default(),
+        )
+        .await
+        .expect("已确认状态必须无副作用地返回");
+    }
+
+    #[tokio::test]
+    async fn uncertain_first_submit_blocks_further_retries() {
+        let session = Arc::new(Mutex::new(SyncSession {
+            videos: vec![Video::new("p1")],
+            first_submit_uncertain: true,
+            ..Default::default()
+        }));
+        let error = commit_unconfirmed(
+            &session,
+            &dummy_bili(),
+            &dummy_upload_config(),
+            None,
+            &Recorder::default(),
+        )
+        .await
+        .expect_err("首投结果不确定时禁止自动重试");
+        assert!(error.to_string().contains("重复稿件"));
+    }
+}

--- a/crates/biliup-cli/src/server/common/upload.rs
+++ b/crates/biliup-cli/src/server/common/upload.rs
@@ -14,10 +14,12 @@ use biliup::bilibili::{BiliBili, ResponseData, Studio, Video};
 use biliup::client::StatelessClient;
 use biliup::credential::login_by_cookies;
 use biliup::error::Kind;
-use biliup::uploader::line::{Line, Probe};
+use biliup::uploader::line::{Line, Probe, StreamParcel, UploadedStream};
 use biliup::uploader::util::SubmitOption;
 use biliup::uploader::{VideoFile, line};
+use bytes::Bytes;
 use error_stack::ResultExt;
+use futures::Stream;
 use futures::StreamExt;
 use futures::stream::Inspect;
 use ormlite::Insert;
@@ -28,11 +30,12 @@ use tokio::pin;
 use tracing::{error, info};
 
 // 辅助结构体
-struct UploadContext {
-    bilibili: BiliBili,
-    line: Line,
-    threads: usize,
-    client: StatelessClient,
+#[derive(Clone)]
+pub(crate) struct UploadContext {
+    pub(crate) bilibili: BiliBili,
+    pub(crate) line: Line,
+    pub(crate) threads: usize,
+    pub(crate) client: StatelessClient,
 }
 
 #[derive(Default)]
@@ -102,7 +105,7 @@ where
     execute_postprocessor(paths, ctx).await
 }
 
-async fn initialize_upload_context(
+pub(crate) async fn initialize_upload_context(
     config: &Config,
     client: &StatelessClient,
     upload_config: &UploadStreamer,
@@ -199,7 +202,10 @@ where
     Ok(uploaded)
 }
 
-async fn upload_single_file(file_path: &Path, context: &UploadContext) -> AppResult<Video> {
+pub(crate) async fn upload_single_file(
+    file_path: &Path,
+    context: &UploadContext,
+) -> AppResult<Video> {
     let video_path = file_path;
     let UploadContext {
         bilibili,
@@ -283,6 +289,69 @@ pub async fn submit_to_bilibili(
     };
     info!("Submit successful");
     Ok(result)
+}
+
+pub async fn edit_to_bilibili(
+    bilibili: &BiliBili,
+    studio: &Studio,
+    submit_api: Option<&str>,
+) -> AppResult<serde_json::Value> {
+    let submit_option = match submit_api {
+        Some(submit) => SubmitOption::from_str(submit).unwrap_or(SubmitOption::App),
+        _ => SubmitOption::App,
+    };
+
+    let result = match submit_option {
+        SubmitOption::Web => bilibili
+            .edit_by_web(studio)
+            .await
+            .change_context(AppError::Unknown)?,
+        _ => bilibili
+            .edit_by_app(studio, None)
+            .await
+            .change_context(AppError::Unknown)?,
+    };
+    info!("Edit successful");
+    Ok(result)
+}
+
+pub(crate) fn aid_from_submit(ret: &ResponseData) -> AppResult<u64> {
+    ret.data
+        .as_ref()
+        .and_then(|v| v.get("aid"))
+        .and_then(|v| v.as_u64().or_else(|| v.as_i64().map(|i| i as u64)))
+        .ok_or_else(|| AppError::Custom("投稿成功但未返回 aid".into()).into())
+}
+
+/// 边录边传：把内存分片流上传到 UPOS。上传并发固定为 3，对齐原 sync-downloader。
+pub(crate) async fn upload_byte_stream_parts<S>(
+    context: &UploadContext,
+    parcel: StreamParcel,
+    stream: S,
+) -> AppResult<UploadedStream>
+where
+    S: Stream<Item = biliup::error::Result<(Bytes, usize)>>,
+{
+    let file_name = parcel.file_name().to_string();
+    let total_size = parcel.total_size();
+    info!("开始流式上传：{file_name} ({total_size} bytes)");
+    info!("线路选择：{:?}", context.line);
+    let instant = Instant::now();
+    let uploaded = parcel
+        .upload_parts(context.client.clone(), 3, stream)
+        .await
+        .change_context(AppError::Unknown)?;
+    let t = instant.elapsed().as_millis().max(1);
+    info!(
+        "Stream parts uploaded: {file_name} => cost {:.2}s, {:.2} MB/s.",
+        t as f64 / 1000.,
+        uploaded.uploaded_size() as f64 / 1000. / t as f64
+    );
+    Ok(uploaded)
+}
+
+pub(crate) async fn complete_byte_stream(uploaded: UploadedStream) -> AppResult<Video> {
+    uploaded.complete().await.change_context(AppError::Unknown)
 }
 
 // 解析投稿的「转载来源」(source) 字段。
@@ -478,6 +547,30 @@ mod tests {
             resolve_source(Some("  https://b23.tv/abc  "), LIVE_URL),
             "https://b23.tv/abc"
         );
+    }
+
+    #[test]
+    fn aid_from_submit_reads_numeric_aid() {
+        let ret: ResponseData = serde_json::from_value(serde_json::json!({
+            "code": 0,
+            "data": {"aid": 12345, "bvid": "BV1xx"},
+            "message": "0",
+            "ttl": 1
+        }))
+        .unwrap();
+        assert_eq!(aid_from_submit(&ret).unwrap(), 12345);
+    }
+
+    #[test]
+    fn aid_from_submit_rejects_missing_data() {
+        let ret: ResponseData = serde_json::from_value(serde_json::json!({
+            "code": 0,
+            "data": {},
+            "message": "0",
+            "ttl": 1
+        }))
+        .unwrap();
+        assert!(aid_from_submit(&ret).is_err());
     }
 }
 

--- a/crates/biliup-cli/src/server/config.rs
+++ b/crates/biliup-cli/src/server/config.rs
@@ -12,9 +12,13 @@ use struct_patch::Patch;
 #[patch(attribute(derive(Debug, Clone, Default, Deserialize, Serialize)))]
 pub struct Config {
     // ===== 全局录播与上传设置 =====
-    /// 下载器类型：streamlink | ffmpeg | stream-gears | 自定义
+    /// 下载器类型：streamlink | ffmpeg | stream-gears | sync-downloader | 自定义
     #[serde(default)]
     pub downloader: Option<DownloaderType>,
+
+    /// 边录边传额外保存本地目录（仅 sync-downloader）
+    #[serde(default)]
+    pub sync_save_dir: Option<String>,
 
     /// 文件大小限制（字节）
     #[patch(attribute(serde(default, deserialize_with = "deserialize_option_patch")))]
@@ -611,5 +615,17 @@ mod tests {
         assert_eq!(config.file_size, None);
         assert_eq!(config.segment_time, Some("01:00:00".to_string()));
         assert!(config.validate_segment_limits().is_ok());
+    }
+
+    #[test]
+    fn deserialize_sync_save_dir() {
+        let config: Config =
+            serde_json::from_str(r#"{"sync_save_dir":"/tmp/sync","downloader":"sync-downloader"}"#)
+                .unwrap();
+        assert_eq!(config.sync_save_dir.as_deref(), Some("/tmp/sync"));
+        assert_eq!(config.downloader, Some(DownloaderType::SyncDownloader));
+
+        let empty: Config = serde_json::from_str(r#"{}"#).unwrap();
+        assert_eq!(empty.sync_save_dir, None);
     }
 }

--- a/crates/biliup-cli/src/server/core/downloader.rs
+++ b/crates/biliup-cli/src/server/core/downloader.rs
@@ -4,6 +4,8 @@ pub mod ffmpeg_downloader;
 /// Stream-gears下载器实现
 pub mod stream_gears;
 pub mod streamlink;
+/// 边录边传（零落盘流式上传）
+pub mod sync_downloader;
 pub mod ytdlp;
 
 use crate::server::common::timerange;
@@ -11,6 +13,7 @@ use crate::server::common::util::Recorder;
 use crate::server::core::downloader::ffmpeg_downloader::FfmpegDownloader;
 use crate::server::core::downloader::stream_gears::StreamGears;
 use crate::server::core::downloader::streamlink::Streamlink;
+use crate::server::core::downloader::sync_downloader::SyncDownloader;
 use crate::server::core::downloader::ytdlp::YouTubeDownloader;
 use crate::server::errors::{AppError, AppResult};
 use async_trait::async_trait;
@@ -104,6 +107,7 @@ pub enum DownloaderRuntime {
     StreamGears(StreamGears),
     StreamLink(Streamlink),
     YtDlp(YouTubeDownloader),
+    Sync(SyncDownloader),
 }
 
 impl DownloaderRuntime {
@@ -114,8 +118,8 @@ impl DownloaderRuntime {
                 Vec::new(),
                 DownloaderType::FfmpegExternal,
             )),
+            DownloaderType::SyncDownloader => Self::Sync(SyncDownloader::new()),
             _ => Self::StreamGears(StreamGears::new(None)),
-            // ...
         }
     }
 
@@ -129,6 +133,10 @@ impl DownloaderRuntime {
             Self::StreamGears(d) => d.download(callback, download_config).await,
             DownloaderRuntime::StreamLink(d) => d.download(callback, download_config).await,
             Self::YtDlp(d) => d.download(callback, download_config).await,
+            Self::Sync(_) => Err(AppError::Custom(
+                "sync-downloader 应走边录边传专用流程，而不是落盘分段回调".into(),
+            )
+            .into()),
         }
     }
 
@@ -138,6 +146,7 @@ impl DownloaderRuntime {
             Self::StreamGears(d) => d.stop().await,
             DownloaderRuntime::StreamLink(d) => d.stop().await,
             Self::YtDlp(d) => d.stop().await,
+            Self::Sync(d) => d.stop().await,
         }
     }
 }
@@ -325,3 +334,19 @@ fn parse_duration(duration: &str) -> u64 {
 //
 //     Ok(())
 // }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_downloader_is_not_silently_mapped_to_stream_gears() {
+        let runtime = DownloaderRuntime::from_type(DownloaderType::SyncDownloader);
+        assert!(
+            matches!(runtime, DownloaderRuntime::Sync(_)),
+            "选择 sync-downloader 必须走边录边传，不能再落到 stream-gears 落盘"
+        );
+        let gears = DownloaderRuntime::from_type(DownloaderType::StreamGears);
+        assert!(matches!(gears, DownloaderRuntime::StreamGears(_)));
+    }
+}

--- a/crates/biliup-cli/src/server/core/downloader/sync_downloader.rs
+++ b/crates/biliup-cli/src/server/core/downloader/sync_downloader.rs
@@ -1,0 +1,683 @@
+use crate::server::core::downloader::DownloadConfig;
+use crate::server::errors::{AppError, AppResult};
+use bytes::Bytes;
+use error_stack::ResultExt;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdout, Command};
+use tokio::sync::RwLock;
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+use url::Url;
+
+/// 边录边传下载器。
+///
+/// 对齐 Python `biliup/engine/sync_downloader.py`：ffmpeg（HLS 时可选 streamlink）
+/// 把直播流 remux 成 Matroska 写到 stdout，再按 UPOS 分片切给上传端，默认不落盘。
+pub struct SyncDownloader {
+    ffmpeg: Arc<RwLock<Option<Child>>>,
+    streamlink: Arc<RwLock<Option<Child>>>,
+}
+
+impl Default for SyncDownloader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SyncDownloader {
+    pub fn new() -> Self {
+        Self {
+            ffmpeg: Arc::new(RwLock::new(None)),
+            streamlink: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    pub(crate) async fn stop(&self) -> AppResult<()> {
+        self.kill_children().await;
+        Ok(())
+    }
+
+    async fn kill_children(&self) {
+        if let Some(mut child) = self.ffmpeg.write().await.take() {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+        }
+        if let Some(mut child) = self.streamlink.write().await.take() {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+        }
+    }
+
+    /// 启动一段录制并读出第一块数据。没有数据时返回 `None`（对应 Python 空 stdout 重试）。
+    pub async fn start_segment(
+        &self,
+        download_config: &DownloadConfig,
+        max_file_size: u64,
+        token: &CancellationToken,
+    ) -> AppResult<Option<SegmentStdout>> {
+        self.kill_children().await;
+
+        let url = &download_config.url;
+        let hls = is_hls_url(url);
+        let use_streamlink = hls && command_exists("streamlink", "--version");
+        if hls && !use_streamlink {
+            warn!("HLS 流未找到 streamlink，回退为 ffmpeg 直拉");
+        }
+
+        let mut ffmpeg = if use_streamlink {
+            self.spawn_streamlink_ffmpeg(download_config, max_file_size)
+                .await?
+        } else {
+            self.spawn_ffmpeg(download_config, max_file_size, false)?
+        };
+
+        drain_stderr(&mut ffmpeg, "ffmpeg");
+        let mut stdout = ffmpeg
+            .stdout
+            .take()
+            .ok_or_else(|| AppError::Custom("failed to capture ffmpeg stdout".to_string()))?;
+        *self.ffmpeg.write().await = Some(ffmpeg);
+
+        let mut buf = vec![0u8; 4096];
+        let first = tokio::select! {
+            _ = token.cancelled() => {
+                self.kill_children().await;
+                return Ok(None);
+            }
+            read = timeout(Duration::from_secs(20), stdout.read(&mut buf)) => read,
+        };
+
+        match first {
+            Ok(Ok(0)) | Err(_) => {
+                self.kill_children().await;
+                Ok(None)
+            }
+            Ok(Ok(n)) => {
+                buf.truncate(n);
+                Ok(Some(SegmentStdout {
+                    stdout,
+                    peeked: buf,
+                }))
+            }
+            Ok(Err(e)) => {
+                self.kill_children().await;
+                Err(AppError::Custom(format!("读取 ffmpeg stdout 失败: {e}")).into())
+            }
+        }
+    }
+
+    fn spawn_ffmpeg(
+        &self,
+        download_config: &DownloadConfig,
+        max_file_size: u64,
+        pipe_input: bool,
+    ) -> AppResult<Child> {
+        let args = build_ffmpeg_args(download_config, max_file_size, pipe_input);
+        let mut cmd = Command::new("ffmpeg");
+        cmd.args(&args)
+            .stdin(if pipe_input {
+                Stdio::piped()
+            } else {
+                Stdio::null()
+            })
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        info!(cmd = ?cmd, "Starting sync-downloader ffmpeg");
+        cmd.spawn().change_context(AppError::Custom(
+            "未安装 FFmpeg 或不在 PATH 中，边录边传无法启动".into(),
+        ))
+    }
+
+    async fn spawn_streamlink_ffmpeg(
+        &self,
+        download_config: &DownloadConfig,
+        max_file_size: u64,
+    ) -> AppResult<Child> {
+        let sl_args = build_streamlink_args(download_config);
+        let mut sl_cmd = Command::new("streamlink");
+        sl_cmd
+            .args(&sl_args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        info!(cmd = ?sl_cmd, "Starting sync-downloader streamlink");
+        let mut streamlink = sl_cmd
+            .spawn()
+            .change_context(AppError::Custom("启动 streamlink 失败".into()))?;
+        drain_stderr(&mut streamlink, "streamlink");
+        let mut sl_stdout = streamlink
+            .stdout
+            .take()
+            .ok_or_else(|| AppError::Custom("failed to capture streamlink stdout".to_string()))?;
+        *self.streamlink.write().await = Some(streamlink);
+
+        let mut ffmpeg = self.spawn_ffmpeg(download_config, max_file_size, true)?;
+        let mut ff_stdin = ffmpeg
+            .stdin
+            .take()
+            .ok_or_else(|| AppError::Custom("failed to capture ffmpeg stdin".to_string()))?;
+        tokio::spawn(async move {
+            let _ = tokio::io::copy(&mut sl_stdout, &mut ff_stdin).await;
+        });
+        Ok(ffmpeg)
+    }
+}
+
+pub struct SegmentStdout {
+    pub stdout: ChildStdout,
+    pub peeked: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PumpResult {
+    pub actual_size: u64,
+    pub streamed_size: u64,
+    pub stream_complete: bool,
+}
+
+/// 把 ffmpeg stdout 同时写入临时文件并按 UPOS chunk 切给上传通道。
+///
+/// 通道跟不上时停止预传但继续完整落盘，调用方随后可按实际长度回退为文件上传。
+pub async fn pump_chunks<R: tokio::io::AsyncRead + Unpin>(
+    mut stdout: R,
+    peeked: Vec<u8>,
+    chunk_size: usize,
+    total_size: u64,
+    save_path: PathBuf,
+    tx: async_channel::Sender<Bytes>,
+    token: CancellationToken,
+) -> AppResult<PumpResult> {
+    if let Some(dir) = save_path.parent() {
+        tokio::fs::create_dir_all(dir)
+            .await
+            .change_context(AppError::Unknown)?;
+    }
+    let mut save = tokio::fs::File::create(&save_path)
+        .await
+        .change_context(AppError::Unknown)?;
+
+    let mut buffer = Vec::new();
+    let mut remaining = total_size;
+    let mut written = 0u64;
+    let mut streamed = 0u64;
+    let mut incoming = peeked;
+    let mut tmp = vec![0u8; 64 * 1024];
+    let mut sender = Some(tx);
+
+    loop {
+        if remaining == 0 {
+            break;
+        }
+        if incoming.is_empty() {
+            let read = tokio::select! {
+                _ = token.cancelled() => {
+                    return Err(AppError::Custom("边录边传录制已取消".into()).into());
+                }
+                read = stdout.read(&mut tmp) => read,
+            };
+            match read {
+                Ok(0) => break,
+                Ok(n) => incoming = tmp[..n].to_vec(),
+                Err(e) => {
+                    return Err(AppError::Custom(format!("读取 ffmpeg stdout 失败: {e}")).into());
+                }
+            }
+        }
+        let take = remaining.min(incoming.len() as u64) as usize;
+        tokio::select! {
+            _ = token.cancelled() => {
+                return Err(AppError::Custom("边录边传录制已取消".into()).into());
+            }
+            result = save.write_all(&incoming[..take]) => {
+                result.change_context(AppError::Unknown)?;
+            }
+        }
+        written += take as u64;
+        let chunks = take_full_chunks(&mut buffer, &incoming[..take], chunk_size, &mut remaining);
+        if let Some(tx) = sender.as_ref() {
+            for chunk in chunks {
+                let len = chunk.len() as u64;
+                if tx.try_send(chunk).is_ok() {
+                    streamed += len;
+                } else {
+                    warn!("流式上传跟不上录制速度，停止预传并保留临时文件回退");
+                    sender.take();
+                    buffer.clear();
+                    break;
+                }
+            }
+        }
+        incoming.drain(..take);
+    }
+
+    if written == total_size
+        && let Some(chunk) = finish_chunks(buffer, chunk_size)
+        && let Some(tx) = sender.as_ref()
+    {
+        let len = chunk.len() as u64;
+        let sent = tokio::select! {
+            _ = token.cancelled() => {
+                return Err(AppError::Custom("边录边传录制已取消".into()).into());
+            }
+            result = tx.send(chunk) => result.is_ok(),
+        };
+        if sent {
+            streamed += len;
+        } else {
+            sender.take();
+        }
+    }
+    drop(sender);
+    save.flush().await.change_context(AppError::Unknown)?;
+    Ok(PumpResult {
+        actual_size: written,
+        streamed_size: streamed,
+        stream_complete: written == total_size && streamed == total_size,
+    })
+}
+
+/// 把 `file_size` 向上对齐到 10MiB，缺省 2GiB。对齐 Python sync_download。
+pub fn align_file_size(file_size: Option<u64>) -> u64 {
+    const MIN: u64 = 10 * 1024 * 1024;
+    const DEFAULT: u64 = 2 * 1024 * 1024 * 1024;
+    let size = match file_size {
+        Some(s) if s > 0 => s,
+        _ => DEFAULT,
+    };
+    size.div_ceil(MIN) * MIN
+}
+
+pub fn is_hls_url(url: &str) -> bool {
+    Url::parse(url)
+        .map(|parsed| parsed.path().contains(".m3u8"))
+        .unwrap_or_else(|_| url.contains(".m3u8"))
+}
+
+/// 把新到的数据写入缓冲，满 `chunk_size` 就切出去；同时不超过 `remaining`。
+pub fn take_full_chunks(
+    buffer: &mut Vec<u8>,
+    incoming: &[u8],
+    chunk_size: usize,
+    remaining: &mut u64,
+) -> Vec<Bytes> {
+    if *remaining == 0 || incoming.is_empty() || chunk_size == 0 {
+        return Vec::new();
+    }
+    let take = (*remaining as usize).min(incoming.len());
+    buffer.extend_from_slice(&incoming[..take]);
+    *remaining -= take as u64;
+    let mut chunks = Vec::new();
+    while buffer.len() >= chunk_size {
+        let chunk: Vec<u8> = buffer.drain(..chunk_size).collect();
+        chunks.push(Bytes::from(chunk));
+    }
+    chunks
+}
+
+/// 流结束时返回实际尾块，不向媒体尾部补零。
+pub fn finish_chunks(buffer: Vec<u8>, chunk_size: usize) -> Option<Bytes> {
+    if buffer.is_empty() || chunk_size == 0 {
+        return None;
+    }
+    Some(Bytes::from(buffer))
+}
+
+pub fn build_ffmpeg_args(
+    download_config: &DownloadConfig,
+    max_file_size: u64,
+    pipe_input: bool,
+) -> Vec<String> {
+    let mut args = vec![
+        "-loglevel".to_string(),
+        "error".to_string(),
+        "-y".to_string(),
+    ];
+    if !pipe_input {
+        if !download_config.headers.is_empty() {
+            let headers_str = format_ffmpeg_headers(&download_config.headers);
+            args.extend(["-headers".to_string(), headers_str]);
+        }
+        args.extend(["-rw_timeout".to_string(), "20000000".to_string()]);
+        if is_hls_url(&download_config.url) {
+            args.extend(["-max_reload".to_string(), "1000".to_string()]);
+        }
+        args.extend(["-fflags".to_string(), "+genpts".to_string()]);
+        args.extend(["-i".to_string(), download_config.url.clone()]);
+    } else {
+        args.extend(["-fflags".to_string(), "+genpts".to_string()]);
+        args.extend(["-i".to_string(), "pipe:0".to_string()]);
+    }
+
+    args.extend(["-fs".to_string(), max_file_size.to_string()]);
+    if let Some(remaining) = download_config.time_range_remaining() {
+        args.extend(["-t".to_string(), remaining]);
+    }
+    args.extend([
+        "-c:v".to_string(),
+        "copy".to_string(),
+        "-c:a".to_string(),
+        "copy".to_string(),
+        "-reset_timestamps".to_string(),
+        "1".to_string(),
+        "-avoid_negative_ts".to_string(),
+        "make_zero".to_string(),
+        "-f".to_string(),
+        "matroska".to_string(),
+        "-".to_string(),
+    ]);
+    args
+}
+
+pub fn build_streamlink_args(download_config: &DownloadConfig) -> Vec<String> {
+    let mut args = vec![
+        "--stream-segment-threads".to_string(),
+        "3".to_string(),
+        "--hls-playlist-reload-attempts".to_string(),
+        "1".to_string(),
+    ];
+    for (key, value) in &download_config.headers {
+        args.push("--http-header".to_string());
+        args.push(format!("{key}={value}"));
+    }
+    args.push(download_config.url.clone());
+    args.push("best".to_string());
+    args.push("-O".to_string());
+    args
+}
+
+fn format_ffmpeg_headers(headers: &HashMap<String, String>) -> String {
+    headers
+        .iter()
+        .map(|(k, v)| format!("{k}: {v}\r\n"))
+        .collect()
+}
+
+fn command_exists(name: &str, arg: &str) -> bool {
+    std::process::Command::new(name)
+        .arg(arg)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn drain_stderr(child: &mut Child, prefix: &'static str) {
+    if let Some(stderr) = child.stderr.take() {
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                info!("[{prefix}] {line}");
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::core::downloader::DownloadConfig;
+    use biliup::downloader::live::{
+        Douyin, LiveCredentials, LiveOptions, LivePlugin, LiveRequest, LiveStatus,
+    };
+
+    #[test]
+    fn align_file_size_rounds_up_to_10mib() {
+        assert_eq!(align_file_size(Some(1)), 10 * 1024 * 1024);
+        assert_eq!(align_file_size(Some(10 * 1024 * 1024)), 10 * 1024 * 1024);
+        assert_eq!(
+            align_file_size(Some(2_621_440_000)),
+            2_621_440_000,
+            "默认 2.5GiB 已经是 10MiB 对齐"
+        );
+        assert_eq!(align_file_size(None), 205 * 10 * 1024 * 1024);
+        assert_eq!(align_file_size(Some(0)), 205 * 10 * 1024 * 1024);
+    }
+
+    #[test]
+    fn hls_is_detected_from_path_not_query() {
+        assert!(is_hls_url("https://example.com/live/index.m3u8"));
+        assert!(is_hls_url("https://example.com/live/index.m3u8?token=abc"));
+        assert!(!is_hls_url("https://example.com/live.flv"));
+        assert!(!is_hls_url("https://example.com/room/m3u8-not-ext"));
+    }
+
+    #[test]
+    fn take_full_chunks_splits_and_caps_at_remaining() {
+        let mut buffer = Vec::new();
+        let mut remaining = 10u64;
+        let chunks = take_full_chunks(&mut buffer, b"abcdefghijklmnop", 4, &mut remaining);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(&chunks[0][..], b"abcd");
+        assert_eq!(&chunks[1][..], b"efgh");
+        assert_eq!(&buffer[..], b"ij");
+        assert_eq!(remaining, 0);
+    }
+
+    #[test]
+    fn finish_chunks_keeps_the_last_part_exact() {
+        let chunk = finish_chunks(b"hi".to_vec(), 4).unwrap();
+        assert_eq!(&chunk[..], b"hi");
+        assert!(finish_chunks(Vec::new(), 4).is_none());
+    }
+
+    #[test]
+    fn ffmpeg_args_use_matroska_stdout_and_size_limit() {
+        let config = DownloadConfig {
+            url: "https://example.com/live.flv".into(),
+            headers: HashMap::from([("Referer".into(), "https://example.com/".into())]),
+            ..Default::default()
+        };
+        let args = build_ffmpeg_args(&config, 10 * 1024 * 1024, false);
+        assert!(args.contains(&"-f".to_string()));
+        assert!(args.contains(&"matroska".to_string()));
+        assert_eq!(args.last().map(String::as_str), Some("-"));
+        assert!(args.windows(2).any(|w| w[0] == "-fs" && w[1] == "10485760"));
+        assert!(
+            args.windows(2)
+                .any(|w| w[0] == "-i" && w[1] == "https://example.com/live.flv")
+        );
+        assert!(args.contains(&"-headers".to_string()));
+    }
+
+    #[test]
+    fn ffmpeg_pipe_input_does_not_repeat_http_headers() {
+        let config = DownloadConfig {
+            url: "https://example.com/live/index.m3u8".into(),
+            headers: HashMap::from([("User-Agent".into(), "test".into())]),
+            ..Default::default()
+        };
+        let args = build_ffmpeg_args(&config, 1024, true);
+        assert!(!args.contains(&"-headers".to_string()));
+        assert!(args.windows(2).any(|w| w[0] == "-i" && w[1] == "pipe:0"));
+    }
+
+    #[tokio::test]
+    async fn pump_short_stream_spools_fully_but_marks_incomplete() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("short.bin");
+        let data: Vec<u8> = (0u8..10).collect();
+        let (tx, rx) = async_channel::bounded(6);
+        let result = pump_chunks(
+            &data[..],
+            Vec::new(),
+            4,
+            16,
+            path.clone(),
+            tx,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.actual_size, 10);
+        assert_eq!(result.streamed_size, 8, "只应流出完整块，尾部留给文件回退");
+        assert!(!result.stream_complete);
+        let mut chunks = Vec::new();
+        while let Ok(chunk) = rx.try_recv() {
+            chunks.push(chunk);
+        }
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(std::fs::read(&path).unwrap(), data, "临时文件必须完整落盘");
+    }
+
+    #[tokio::test]
+    async fn pump_exact_total_streams_all_chunks_with_short_tail() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("exact.bin");
+        // ffmpeg -fs 会略微超出限制，超出部分应被丢弃
+        let data: Vec<u8> = (0u8..13).collect();
+        let (tx, rx) = async_channel::bounded(6);
+        let result = pump_chunks(
+            &data[..],
+            Vec::new(),
+            4,
+            10,
+            path.clone(),
+            tx,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.actual_size, 10);
+        assert_eq!(result.streamed_size, 10);
+        assert!(result.stream_complete);
+        let mut chunks = Vec::new();
+        while let Ok(chunk) = rx.try_recv() {
+            chunks.push(chunk);
+        }
+        assert_eq!(
+            chunks.iter().map(|c| c.len()).collect::<Vec<_>>(),
+            vec![4, 4, 2],
+            "尾块按实际长度发送，不补零"
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), &data[..10]);
+    }
+
+    #[tokio::test]
+    async fn pump_full_queue_degrades_to_spool_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("slow.bin");
+        let data: Vec<u8> = (0u8..12).collect();
+        // 容量 1 且无人消费：第二块 try_send 失败后应放弃预传、继续落盘
+        let (tx, rx) = async_channel::bounded(1);
+        let result = pump_chunks(
+            &data[..],
+            Vec::new(),
+            4,
+            12,
+            path.clone(),
+            tx,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.actual_size, 12);
+        assert_eq!(result.streamed_size, 4);
+        assert!(!result.stream_complete);
+        assert_eq!(std::fs::read(&path).unwrap(), data);
+        drop(rx);
+    }
+
+    #[tokio::test]
+    async fn pump_cancellation_aborts_recording() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("cancel.bin");
+        // simplex 读端在写端不写入时保持 pending，确保 select 只能命中取消分支
+        let (reader, _writer) = tokio::io::simplex(8);
+        let (tx, _rx) = async_channel::bounded::<Bytes>(6);
+        let token = CancellationToken::new();
+        token.cancel();
+        let result = pump_chunks(reader, Vec::new(), 4, 16, path, tx, token).await;
+        assert!(result.is_err(), "取消后 pump 必须返回错误而不是伪装成功");
+    }
+
+    #[tokio::test]
+    #[ignore = "需要外网、正在开播的抖音直播间和 PATH 中的 ffmpeg"]
+    async fn real_douyin_stream_remuxes_to_matroska_chunks() {
+        let test_url = std::env::var("DOUYIN_TEST_URL")
+            .unwrap_or_else(|_| "https://live.douyin.com/451984634216".to_string());
+        let status = Douyin::new()
+            .check_stream(LiveRequest {
+                client: reqwest::Client::new(),
+                url: test_url.clone(),
+                name: "sync-real-test".to_string(),
+                options: LiveOptions::default(),
+                credentials: LiveCredentials::default(),
+            })
+            .await
+            .expect("抖音开播检测不应返回硬错误");
+        let stream = match status {
+            LiveStatus::Live { stream } => stream,
+            LiveStatus::Offline => panic!("测试直播间当前未开播：{test_url}"),
+        };
+
+        let total_size = 2 * 1024 * 1024;
+        let chunk_size = 256 * 1024;
+        let config = DownloadConfig {
+            url: stream.raw_stream_url,
+            file_size: Some(total_size),
+            headers: stream.stream_headers,
+            ..Default::default()
+        };
+        let downloader = SyncDownloader::new();
+        let segment = downloader
+            .start_segment(&config, total_size, &CancellationToken::new())
+            .await
+            .expect("启动真实 ffmpeg 管道失败")
+            .expect("ffmpeg 未产生输出");
+        let (tx, rx) = async_channel::bounded(6);
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let save_path = temp.path().join("real-sync-test.mkv");
+        let pump_result = tokio::time::timeout(
+            Duration::from_secs(60),
+            pump_chunks(
+                segment.stdout,
+                segment.peeked,
+                chunk_size,
+                total_size,
+                save_path.clone(),
+                tx,
+                CancellationToken::new(),
+            ),
+        )
+        .await;
+        downloader.stop().await.expect("停止 ffmpeg 失败");
+        let pump = pump_result
+            .expect("读取真实 ffmpeg 输出超时")
+            .expect("切分真实 ffmpeg 输出失败");
+
+        let mut chunks = Vec::new();
+        while let Ok(chunk) = rx.recv().await {
+            chunks.push(chunk);
+        }
+        assert!(
+            pump.actual_size > 100,
+            "真实直播流输出过小：{}",
+            pump.actual_size
+        );
+        assert!(!chunks.is_empty(), "真实直播流没有生成上传分块");
+        assert_eq!(&chunks[0][..4], &[0x1a, 0x45, 0xdf, 0xa3]);
+        assert!(chunks.iter().all(|chunk| chunk.len() == chunk_size));
+        let uploaded_bytes: usize = chunks.iter().map(Bytes::len).sum();
+        assert_eq!(uploaded_bytes, pump.actual_size as usize);
+        assert_eq!(
+            std::fs::metadata(save_path).unwrap().len(),
+            pump.actual_size
+        );
+        eprintln!(
+            "LIVE title={} written={} chunks={} chunk_size={}",
+            stream.title,
+            pump.actual_size,
+            chunks.len(),
+            chunk_size
+        );
+    }
+}

--- a/crates/biliup/src/downloader/live/douyin.rs
+++ b/crates/biliup/src/downloader/live/douyin.rs
@@ -242,14 +242,7 @@ impl<'a> DouyinLive<'a> {
             return Ok(true);
         }
 
-        let web_rid = self
-            .url
-            .split("douyin.com/")
-            .nth(1)
-            .and_then(|part| part.split('/').next())
-            .and_then(|part| part.split('?').next())
-            .map(|part| part.trim_start_matches('+').to_string())
-            .filter(|part| !part.is_empty())
+        let web_rid = web_rid_from_live_url(&self.url)
             .ok_or_else(|| LiveError::custom("抖音直播间地址错误"))?;
         self.web_rid = Some(web_rid);
         Ok(true)
@@ -362,7 +355,12 @@ impl<'a> DouyinLive<'a> {
         // 的 URL 携带 rtm_expr_tag=reflow_room_info 标记，二者均表明直播已结束。
         // 此时接口仍可能返回 status=2 与可拉取的回放流，需在此判定为未开播，
         // 避免 monitor 循环误判"直播中"并反复录制垫片流。
-        if room_info.get("finish_time").and_then(Value::as_i64).unwrap_or(0) > 0 {
+        if room_info
+            .get("finish_time")
+            .and_then(Value::as_i64)
+            .unwrap_or(0)
+            > 0
+        {
             return Ok(None);
         }
         self.room_id = room_info
@@ -508,6 +506,18 @@ fn sign_query(params: &[(String, String)]) -> LiveResult<String> {
         .map_err(|err| LiveError::custom(format!("编码抖音请求参数失败: {err}")))?;
     let mut abogus = ABogus::new(Some(DOUYIN_USER_AGENT));
     Ok(abogus.generate_abogus(&query, ""))
+}
+
+fn web_rid_from_live_url(url: &str) -> Option<String> {
+    let mut path = url.split("douyin.com/").nth(1)?;
+    path = path.split('?').next().unwrap_or(path);
+    path = path.trim_start_matches('+');
+    // www.douyin.com/live/{web_rid} 与 live.douyin.com/{web_rid}
+    if let Some(rest) = path.strip_prefix("live/") {
+        path = rest;
+    }
+    let web_rid = path.split('/').next()?.trim();
+    (!web_rid.is_empty()).then(|| web_rid.to_string())
 }
 
 fn capture(input: &str, pattern: &str) -> Option<String> {
@@ -960,5 +970,94 @@ impl ABogus {
             .collect();
         let abogus = self.crypto_utility.abogus_encode(&final_values, 0);
         format!("{params}&a_bogus={abogus}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::downloader::live::{LiveCredentials, LiveOptions, LiveRequest, LiveStatus};
+
+    #[test]
+    fn web_rid_from_www_live_path_skips_live_prefix() {
+        assert_eq!(
+            web_rid_from_live_url("https://www.douyin.com/live/68621666216"),
+            Some("68621666216".into())
+        );
+        assert_eq!(
+            web_rid_from_live_url("https://live.douyin.com/68621666216?extra=1"),
+            Some("68621666216".into())
+        );
+        assert_eq!(
+            web_rid_from_live_url("https://www.douyin.com/+68621666216"),
+            Some("68621666216".into())
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "需要外网访问抖音直播间"]
+    async fn douyin_live_room_resolves_and_streams_flv() {
+        use futures::StreamExt;
+
+        let plugin = Douyin::new();
+        let test_url = std::env::var("DOUYIN_TEST_URL")
+            .unwrap_or_else(|_| "https://www.douyin.com/live/68621666216".to_string());
+        let request = LiveRequest {
+            client: reqwest::Client::new(),
+            url: test_url.clone(),
+            name: "sync-test".to_string(),
+            options: LiveOptions::default(),
+            credentials: LiveCredentials::default(),
+        };
+        let status = plugin
+            .check_stream(request)
+            .await
+            .expect("抖音开播检测不应返回硬错误");
+        match status {
+            LiveStatus::Live { stream } => {
+                assert!(!stream.raw_stream_url.is_empty(), "开播时应返回直链");
+                assert_eq!(stream.platform, "douyin");
+                assert_eq!(stream.suffix, "flv");
+                let client = reqwest::Client::new();
+                let mut req = client.get(&stream.raw_stream_url);
+                for (key, value) in &stream.stream_headers {
+                    if let (Ok(name), Ok(val)) = (
+                        reqwest::header::HeaderName::from_bytes(key.as_bytes()),
+                        reqwest::header::HeaderValue::from_str(value),
+                    ) {
+                        req = req.header(name, val);
+                    }
+                }
+                let response = tokio::time::timeout(std::time::Duration::from_secs(15), req.send())
+                    .await
+                    .expect("拉流超时")
+                    .expect("拉流请求失败");
+                assert!(
+                    response.status().is_success(),
+                    "拉流 HTTP {}",
+                    response.status()
+                );
+                let mut body = response.bytes_stream();
+                let first = tokio::time::timeout(std::time::Duration::from_secs(10), body.next())
+                    .await
+                    .expect("读取直播流首包超时")
+                    .expect("直播流为空")
+                    .expect("读取直播流失败");
+                assert!(
+                    first.starts_with(b"FLV"),
+                    "直链首包不是 FLV: {:?}",
+                    first.get(..8)
+                );
+                eprintln!(
+                    "LIVE title={} suffix={} first_bytes={}",
+                    stream.title,
+                    stream.suffix,
+                    first.len()
+                );
+            }
+            LiveStatus::Offline => {
+                panic!("测试直播间当前未开播：{test_url}");
+            }
+        }
     }
 }

--- a/crates/biliup/src/uploader/line.rs
+++ b/crates/biliup/src/uploader/line.rs
@@ -6,11 +6,12 @@ use reqwest::{Body, RequestBuilder};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::ffi::OsStr;
+use std::path::Path;
 
 use crate::client::StatelessClient;
 use crate::error::Kind::{Custom, RateLimit};
 use crate::uploader::bilibili::{BiliBili, Video};
-use crate::uploader::line::upos::Upos;
+use crate::uploader::line::upos::{Upos, UposPart};
 use std::time::Instant;
 use tracing::info;
 
@@ -117,6 +118,7 @@ impl Probe {
     }
 }
 
+#[derive(Clone)]
 enum Bucket {
     Upos(upos::Bucket),
 }
@@ -130,15 +132,130 @@ pub struct Line {
     cost: u128,
 }
 
+pub struct StreamParcel {
+    line: Bucket,
+    file_name: String,
+    total_size: u64,
+}
+
+pub struct UploadedStream {
+    upos: Upos,
+    file_name: String,
+    declared_size: u64,
+    parts: Vec<UposPart>,
+    uploaded_size: u64,
+}
+
+impl UploadedStream {
+    pub fn declared_size(&self) -> u64 {
+        self.declared_size
+    }
+
+    pub fn uploaded_size(&self) -> u64 {
+        self.uploaded_size
+    }
+
+    pub fn parts_len(&self) -> usize {
+        self.parts.len()
+    }
+
+    pub async fn complete(self) -> Result<Video> {
+        let video = self
+            .upos
+            .get_ret_video_info(&self.parts, Path::new(&self.file_name))
+            .await?;
+        Ok(with_stream_video_title(video, &self.file_name))
+    }
+}
+
+impl StreamParcel {
+    pub fn chunk_size(&self) -> usize {
+        match &self.line {
+            Bucket::Upos(bucket) => bucket.chunk_size,
+        }
+    }
+
+    pub fn total_size(&self) -> u64 {
+        self.total_size
+    }
+
+    pub fn file_name(&self) -> &str {
+        &self.file_name
+    }
+
+    pub async fn upload_stream<S, B>(
+        self,
+        client: StatelessClient,
+        limit: usize,
+        stream: S,
+    ) -> Result<Video>
+    where
+        S: Stream<Item = Result<(B, usize)>>,
+        B: Into<Body> + Clone,
+    {
+        self.upload_parts(client, limit, stream)
+            .await?
+            .complete()
+            .await
+    }
+
+    pub async fn upload_parts<S, B>(
+        self,
+        client: StatelessClient,
+        limit: usize,
+        stream: S,
+    ) -> Result<UploadedStream>
+    where
+        S: Stream<Item = Result<(B, usize)>>,
+        B: Into<Body> + Clone,
+    {
+        match self.line {
+            Bucket::Upos(bucket) => {
+                let upos = Upos::from(client, bucket).await?;
+                let mut parts = Vec::new();
+                let mut uploaded_size = 0u64;
+                {
+                    let uploaded = upos.upload_stream(stream, self.total_size, limit).await?;
+                    tokio::pin!(uploaded);
+                    while let Some((part, size)) = uploaded.try_next().await? {
+                        parts.push(part);
+                        uploaded_size += size as u64;
+                    }
+                }
+                Ok(UploadedStream {
+                    upos,
+                    file_name: self.file_name,
+                    declared_size: self.total_size,
+                    parts,
+                    uploaded_size,
+                })
+            }
+        }
+    }
+}
+
+fn with_stream_video_title(mut video: Video, file_name: &str) -> Video {
+    if video.title.is_none()
+        && let Some(stem) = Path::new(file_name).file_stem().and_then(OsStr::to_str)
+    {
+        video.title = Some(if stem.chars().count() >= 80 {
+            Video::truncate_title(stem, 80)
+        } else {
+            stem.to_string()
+        });
+    }
+    video
+}
+
 impl Line {
-    pub async fn pre_upload(&self, bili: &BiliBili, video_file: VideoFile) -> Result<Parcel> {
-        let total_size = video_file.total_size;
-        let file_name = video_file.file_name.clone();
+    async fn request_bucket(
+        &self,
+        bili: &BiliBili,
+        file_name: &str,
+        total_size: u64,
+    ) -> Result<Bucket> {
         let profile = "ugcupos/bup"; // ugcfx/bup 需上传视频metadata和frame.zip
         let params = json!({
-            // "probe_version": "20221109",
-            // "upcdn": "",
-            // "zone": "",
             "name": file_name,
             "r": self.os, // upos
             "profile": profile,
@@ -172,7 +289,6 @@ impl Line {
                     .and_then(|m| m.as_str())
                     .unwrap_or("上传过快")
                     .to_string();
-                // 直接返回限流错误，让调用方决定如何处理
                 return Err(RateLimit { code, message });
             }
 
@@ -183,14 +299,34 @@ impl Line {
         }
 
         match self.os {
-            Uploader::Upos => Ok(Parcel {
-                line: Bucket::Upos(response.json().await?),
-                video_file,
-            }),
-            // _ => {
-            //     panic!("unsupported")
-            // }
+            Uploader::Upos => Ok(Bucket::Upos(response.json().await?)),
         }
+    }
+
+    pub async fn pre_upload(&self, bili: &BiliBili, video_file: VideoFile) -> Result<Parcel> {
+        let bucket = self
+            .request_bucket(bili, &video_file.file_name, video_file.total_size)
+            .await?;
+        Ok(Parcel {
+            line: bucket,
+            video_file,
+        })
+    }
+
+    /// 边录边传：在还没有完整文件时，按预声明大小申请 UPOS 上传。
+    pub async fn pre_upload_stream(
+        &self,
+        bili: &BiliBili,
+        file_name: impl Into<String>,
+        total_size: u64,
+    ) -> Result<StreamParcel> {
+        let file_name = file_name.into();
+        let bucket = self.request_bucket(bili, &file_name, total_size).await?;
+        Ok(StreamParcel {
+            line: bucket,
+            file_name,
+            total_size,
+        })
     }
 }
 

--- a/crates/biliup/src/uploader/line/upos.rs
+++ b/crates/biliup/src/uploader/line/upos.rs
@@ -12,8 +12,8 @@ use std::path::Path;
 use std::time::Duration;
 
 use crate::client::StatelessClient;
-use crate::retry;
 use crate::uploader::bilibili::Video;
+use crate::{retry, retry_with_config};
 
 pub struct Upos {
     client: StatelessClient,
@@ -22,7 +22,7 @@ pub struct Upos {
     upload_id: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Bucket {
     pub chunk_size: usize,
     auth: String,
@@ -42,6 +42,13 @@ pub struct Protocol<'a> {
     part_number: usize,
     start: u64,
     end: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UposPart {
+    pub(crate) part_number: usize,
+    e_tag: String,
 }
 
 impl Upos {
@@ -80,13 +87,13 @@ impl Upos {
         })
     }
 
-    pub async fn upload_stream<'a, F, B>(
+    pub(crate) async fn upload_stream<'a, F, B>(
         &'a self,
         // file: std::fs::File,
         stream: F,
         total_size: u64,
         limit: usize,
-    ) -> Result<impl Stream<Item = Result<(serde_json::Value, usize)>> + 'a>
+    ) -> Result<impl Stream<Item = Result<(UposPart, usize)>> + 'a>
     where
         F: Stream<Item = Result<(B, usize)>> + 'a,
         B: Into<Body> + Clone,
@@ -98,7 +105,7 @@ impl Upos {
         // let parts_cell = &RefCell::new(parts);
         let chunk_size = self.bucket.chunk_size;
         // 获取分块数量
-        let chunks_num = (total_size as f64 / chunk_size as f64).ceil() as usize;
+        let chunks_num = total_size.div_ceil(chunk_size as u64) as usize;
         // let file = tokio::io::BufReader::with_capacity(chunk_size, file);
         let client = &self.client.client;
         let url = &self.url;
@@ -138,7 +145,13 @@ impl Upos {
                 })
                 .await?;
 
-                Ok::<_, Kind>((json!({"partNumber": params.chunk + 1, "eTag": "etag"}), len))
+                Ok::<_, Kind>((
+                    UposPart {
+                        part_number: params.chunk + 1,
+                        e_tag: "etag".to_string(),
+                    },
+                    len,
+                ))
             })
             .buffer_unordered(limit);
         Ok(stream)
@@ -147,9 +160,11 @@ impl Upos {
     /// 通知视频上传完成并获取视频信息
     pub(crate) async fn get_ret_video_info(
         &self,
-        parts: &[serde_json::Value],
+        parts: &[UposPart],
         path: &Path,
     ) -> Result<Video> {
+        let parts = sorted_parts(parts)?;
+
         // println!("{:?}", parts_cell.borrow());
         let url = reqwest::Url::parse_with_params(
             &self.url,
@@ -165,23 +180,32 @@ impl Upos {
             ],
         )
         .map_err(|e| Kind::Custom(e.to_string()))?;
-        let res: serde_json::Value = self
-            .client
-            .client_with_middleware
-            .post(url)
-            .header(
-                "X-Upos-Auth",
-                header::HeaderValue::from_str(&self.bucket.auth)?,
-            )
-            .json(&json!({ "parts": parts }))
-            .timeout(Duration::from_secs(60))
-            .send()
-            .await?
-            .json()
-            .await?;
-        if res["OK"] != 1 {
-            return Err(Kind::Custom(res.to_string()));
-        }
+        let res = retry_with_config(
+            || async {
+                let response = self
+                    .client
+                    .client_with_middleware
+                    .post(url.clone())
+                    .header(
+                        "X-Upos-Auth",
+                        header::HeaderValue::from_str(&self.bucket.auth)?,
+                    )
+                    .json(&json!({ "parts": parts }))
+                    .timeout(Duration::from_secs(60))
+                    .send()
+                    .await?
+                    .error_for_status()?;
+                let value: serde_json::Value = response.json().await?;
+                if value["OK"] != 1 {
+                    return Err(Kind::Custom(value.to_string()));
+                }
+                Ok(value)
+            },
+            2,
+            None::<fn(&Kind) -> bool>,
+        )
+        .await?;
+        debug_assert_eq!(res["OK"], 1);
         let filename = Path::new(&self.bucket.upos_uri)
             .file_stem()
             .unwrap()
@@ -200,5 +224,50 @@ impl Upos {
             filename: truncated_filename,
             desc: "".into(),
         })
+    }
+}
+
+fn sorted_parts(parts: &[UposPart]) -> Result<Vec<UposPart>> {
+    let mut parts = parts.to_vec();
+    parts.sort_by_key(|part| part.part_number);
+    for (index, part) in parts.iter().enumerate() {
+        if part.part_number != index + 1 {
+            return Err(Kind::Custom(format!(
+                "UPOS parts 不连续：期望 partNumber={}，实际={}",
+                index + 1,
+                part.part_number
+            )));
+        }
+    }
+    Ok(parts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{UposPart, sorted_parts};
+
+    fn part(part_number: usize) -> UposPart {
+        UposPart {
+            part_number,
+            e_tag: "etag".to_string(),
+        }
+    }
+
+    #[test]
+    fn complete_parts_are_sorted_by_part_number() {
+        let parts = sorted_parts(&[part(3), part(1), part(2)]).unwrap();
+        assert_eq!(
+            parts
+                .into_iter()
+                .map(|part| part.part_number)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn complete_parts_must_be_contiguous() {
+        assert!(sorted_parts(&[part(1), part(3)]).is_err());
+        assert!(sorted_parts(&[part(1), part(1)]).is_err());
     }
 }


### PR DESCRIPTION
## 问题

Rust 重写后 `sync-downloader` 在 `DownloaderRuntime::from_type()` 中被静默映射为 stream-gears 落盘下载，「边录边传」实际变成了「录完再传」，与 #1612 描述一致。原 Python 实现（`biliup/engine/sync_downloader.py`）已在弹幕 Rust 化时删除。

## 实现

恢复 ffmpeg stdout → UPOS 流式分片上传 → 逐段投稿/追加分 P 的完整链路，并针对旧实现的已知缺陷做了可靠性设计：

- **UPOS 两阶段化**：拆分「上传 parts」与显式 `complete`；parts 按 partNumber 排序并校验连续性，complete 检查 HTTP/业务状态并最多重试 3 次（`line.rs` / `upos.rs`）
- **短流回退**：录制时同时写临时文件（容量 6 的有界通道提供背压）；提前下播、预传落后或上传失败时，放弃流式会话，按临时文件实际长度重新 preupload 上传，不再向 UPOS 提交与声明长度不符的对象，也不再补零填充
- **顺序与会话**：`SyncSession` 跨拉流重连保留 `aid`；分 P 严格按录制顺序提交（晚完成的前序段会阻塞后序段投稿）；首投结果不确定时停止自动重试，避免重复建稿
- **错误与退避**：上传/complete/投稿/edit 的最终错误向上传播；外层重试只在分 P 实际推进后重置退避，持续失败不再零延迟热循环；停止流程设 30 秒清理时限
- **抖音 URL 修复**：`www.douyin.com/live/{id}` 之前被解析成 `web_rid=live`，导致此类房间恒判未开播

配置沿用现有 UI 字段：`downloader: sync-downloader` + 可选 `sync_save_dir`（未配置时用系统临时目录，投稿成功后自动清理）。

## 测试

- [x] `cargo test -p biliup --lib`：66 通过（1 个真实网络测试默认忽略）
- [x] `cargo test -p biliup-cli --lib`：106 通过；`router::tests::static_files_are_limited_to_media_and_known_logs` 在干净 master 检出上以相同方式失败（Windows `canonicalize` 的 `\\?\` 前缀问题），与本 PR 无关
- [x] 新增单测：分块切割/尾块不补零、慢消费者降级落盘、取消中断、分 P 乱序完成时仍按录制顺序提交、UPOS parts 排序与连续性校验、首投不确定守卫、跨重连不重复投稿
- [x] 真实场景验证：用正在开播的抖音直播间跑通「解析直链 → ffmpeg remux → UPOS 分片 → 首 P 投稿 → 第二段 edit 追加」，稿件两个分 P 均转码成功（仅自己可见测试稿）；真实拉流 remux/分块测试保留为 `#[ignore]` 用例，可通过 `DOUYIN_TEST_URL` 指定房间复跑

Closes #1612