### PR TITLE
fix(bilibili): 稿件分页查询复用登录客户端，不再每页新建 Client

### DIFF
--- a/crates/biliup/src/uploader/bilibili.rs
+++ b/crates/biliup/src/uploader/bilibili.rs
@@ -876,20 +876,13 @@ impl BiliBili {
 
     /// 稿件管理
     async fn archives(&self, status: &str, page_num: u32) -> Result<Value> {
-        let url_str = "https://member.bilibili.com/x/web/archives";
-        let params = [("status", status), ("pn", &page_num.to_string())];
-        let url = reqwest::Url::parse_with_params(url_str, &params).unwrap();
-
-        let cookie = self.get_cookie()?;
-        let jar = reqwest::cookie::Jar::default();
-        jar.add_cookie_str(&cookie, &url);
-
-        let res: ResponseData = reqwest::Client::builder()
-            .user_agent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/63.0.3239.108")
-            .cookie_provider(std::sync::Arc::new(jar))
+        // 复用登录时构建的客户端：cookie store 已含全部登录 Cookie，
+        // 且保留代理等配置，避免分页循环中每页新建 Client 和 cookie jar。
+        let res: ResponseData = self
+            .client
+            .get("https://member.bilibili.com/x/web/archives")
+            .query(&[("status", status), ("pn", &page_num.to_string())])
             .timeout(Duration::new(60, 0))
-            .build()?
-            .get(url)
             .send()
             .await?
             .json()


### PR DESCRIPTION
## 问题

`BiliBili::archives()` 在稿件分页查询中每请求一页都重新 `Client::builder().build()` 一个新的 reqwest Client 和 cookie jar，`recent_archives_page` 翻多少页就建多少个客户端。除性能浪费外还有两个实际缺陷：

1. **代理被绕过**：临时 Client 不携带登录时配置的代理，`--proxy` 场景下稿件查询直连，可能失败或泄露真实 IP
2. **Cookie 实际只注入了第一个**：`Jar::add_cookie_str` 按单条 `Set-Cookie` 语义解析，`get_cookie()` 用 `"; "` 拼接的整串 Cookie 中只有第一个键值对生效，其余（如 `SESSDATA` 不在首位时）被当作 Cookie 属性丢弃，查询可能以未登录态发出

## 修复

- `archives()` 改为复用登录时构建的 `self.client`：其 cookie store 在 `set_cookie` 时已逐条插入全部登录 Cookie，UA 与原实现完全一致，并保留代理配置与连接池
- 按原行为为该请求保留 60 秒总超时（`self.client` 仅有连接超时）
- 删除每页新建的 Client、cookie jar 及手工拼接的 URL

## 测试

- [x] `cargo test -p biliup --lib`：63 通过（既有 `archive_tests` 分页与解析用例全部通过）
- [x] `cargo check -p biliup-cli` 通过，`list` 命令等调用方无需改动
- [x] 行为核对：`StatefulClient` 的 UA 与被替换的硬编码 UA 逐字符一致；cookie store 由 `Credential::set_cookie` 逐条插入，域为 `bilibili.com`，对 `member.bilibili.com` 请求全部生效
