### PR TITLE
fix(flv): 使用 write_all 保证 FLV 标签与 JSON 输出完整写入

### DIFF
--- a/crates/biliup/src/downloader/flv_writer.rs
+++ b/crates/biliup/src/downloader/flv_writer.rs
@@ -68,7 +68,9 @@ impl<'a> FlvFile<'a> {
     ) -> std::io::Result<usize> {
         self.write_tag_header(tag_header)?;
         self.buf_writer.write_all(body)?;
-        self.buf_writer.write(previous_tag_size)
+        // write 允许部分写入，短写会静默丢字节并破坏 FLV 结构，必须用 write_all
+        self.buf_writer.write_all(previous_tag_size)?;
+        Ok(previous_tag_size.len())
     }
 
     pub fn write_tag_header(&mut self, tag_header: &TagHeader) -> std::io::Result<()> {
@@ -86,7 +88,9 @@ impl<'a> FlvFile<'a> {
         writer: &mut impl Write,
         previous_tag_size: u32,
     ) -> std::io::Result<usize> {
-        writer.write(&previous_tag_size.to_be_bytes())
+        let bytes = previous_tag_size.to_be_bytes();
+        writer.write_all(&bytes)?;
+        Ok(bytes.len())
     }
 }
 
@@ -104,7 +108,8 @@ pub struct FlvTag<'a> {
 
 pub fn to_json<T: ?Sized + Serialize>(mut writer: impl Write, t: &T) -> std::io::Result<usize> {
     serde_json::to_writer(&mut writer, t)?;
-    writer.write("\n".as_ref())
+    writer.write_all(b"\n")?;
+    Ok(1)
 }
 
 #[derive(Debug, PartialEq, Serialize)]
@@ -123,4 +128,40 @@ pub enum TagDataHeader<'a> {
         composition_time: Option<i32>,
     },
     Script(ScriptData<'a>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 模拟每次调用最多接受 1 字节的 Writer。
+    /// 对这类 Writer，`write` 只写入部分数据也返回 Ok，必须用 `write_all` 才能保证完整写入。
+    struct ShortWriter(Vec<u8>);
+
+    impl Write for ShortWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let take = buf.len().min(1);
+            self.0.extend_from_slice(&buf[..take]);
+            Ok(take)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn previous_tag_size_is_fully_written_even_on_short_writes() {
+        let mut writer = ShortWriter(Vec::new());
+        let written = FlvFile::write_previous_tag_size(&mut writer, 0x0102_0304).unwrap();
+        assert_eq!(written, 4);
+        assert_eq!(writer.0, [0x01, 0x02, 0x03, 0x04]);
+    }
+
+    #[test]
+    fn to_json_writes_trailing_newline_even_on_short_writes() {
+        let mut writer = ShortWriter(Vec::new());
+        to_json(&mut writer, &serde_json::json!({"k": "v"})).unwrap();
+        assert!(writer.0.ends_with(b"\n"));
+    }
 }


### PR DESCRIPTION
## 问题

`flv_writer` 中三处用 `io::Write::write` 写数据：`write` 允许部分写入且将已写字节数作为 `Ok` 返回，调用方均未检查返回值。一旦发生短写（磁盘满前夕、网络文件系统、管道缓冲等场景），字节会静默丢失：

- `write_tag` 末尾的 `previous_tag_size`（4 字节）：短写直接破坏 FLV 标签链，播放器/解析器从该点起无法继续解析后续所有标签
- `write_previous_tag_size`：文件头部的首个 PreviousTagSize，同样风险
- `to_json` 的换行符：`dump-flv` 输出的 NDJSON 断行

## 修复

- 三处全部改为 `write_all`，公开函数签名保持不变（仍返回 `Result<usize>`，语义变为「保证完整写入后返回字节数」）
- 新增短写 Writer 回归测试：模拟每次最多接受 1 字节的 Writer，验证 4 字节 `previous_tag_size` 仍被完整写出（旧实现只会写出 1 字节且不报错）、`to_json` 输出以换行结尾

## 测试

- [x] `cargo test -p biliup --lib`：65 通过（新增 2 项，含既有 `pure_video_stream_segments_without_panic` 等 FLV 写入用例）
- [x] `cargo check -p biliup-cli` 通过，`write_tag` / `to_json` 调用方均丢弃返回值，无需改动
