### PR TITLE
fix(webui): 注册提交前执行表单校验，确认密码规则不再被绕过

### DIFF
--- a/app/(auth)/login/page.jsx
+++ b/app/(auth)/login/page.jsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, {useState} from 'react';
+import React, {useState, useRef} from 'react';
 import {Nav, Avatar, Form, Checkbox, Button, Toast} from '@douyinfe/semi-ui';
 import { IconSemiLogo, IconFeishuLogo, IconHelpCircle, IconBell } from '@douyinfe/semi-icons';
 import styles from './index.module.scss';
@@ -19,6 +19,7 @@ const Component = () => {
     const [password, setPassword] = useState('');
     const [remember, setRemember] = useState(false);
     const [loading, setLoading] = useState(false);
+    const formApi = useRef(null);
 
     // 使用 SWR 检查用户是否存在
     const { data, error, isLoading } = useSWR('/v1/users/biliup', fetcher, {
@@ -34,6 +35,14 @@ const Component = () => {
     const handleSubmit = async () => {
         if (!username || !password) {
             Toast.error('请填写用户名和密码');
+            return;
+        }
+
+        // 提交前执行表单规则校验（注册模式下包含确认密码一致性），
+        // 校验失败时 Semi 会在对应字段下方展示错误信息
+        try {
+            await formApi.current?.validate();
+        } catch {
             return;
         }
 
@@ -125,7 +134,7 @@ const Component = () => {
                         </div>
                     </div>
                     <div className={styles.form}>
-                        <Form className={styles.inputs}>
+                        <Form className={styles.inputs} getFormApi={(api) => (formApi.current = api)}>
                             <Form.Input
                                 label={{ text: "用户名" }}
                                 field="username"
@@ -157,6 +166,7 @@ const Component = () => {
                                     style={{ width: 440 }}
                                     className={styles.formField}
                                     rules={[
+                                        { required: true, message: '请再次输入密码' },
                                         {
                                             validator: (rule, value) => value === password,
                                             message: '两次密码输入不一致'


### PR DESCRIPTION
## 问题

登录页的「注册」按钮直接以 `onClick` 调用 `handleSubmit` 发起 fetch，从不触发 Semi Form 的规则校验。确认密码字段虽然声明了一致性 `validator`，但该规则从未执行：注册时确认密码留空、或与密码不一致，都会被成功提交，确认密码形同虚设。

## 修复

- 提交前先 `await formApi.validate()`：校验失败时终止提交，Semi 在对应字段下方展示错误信息（登录模式下无带规则字段，行为不变）
- 通过 `getFormApi` 持有 formApi 引用
- 为确认密码补充 `required` 规则：留空时提示「请再次输入密码」，而不是笼统的「两次密码输入不一致」

## 测试

- [x] `npm run build`：全部 13 个路由构建通过，`/login` 正常编译
- [x] `npx next lint --file "app/(auth)/login/page.jsx"`：无新增告警（仅既有的 `no-img-element` 警告）
- [x] 行为核对：注册模式下确认密码为空 → `required` 规则拦截；不一致 → `validator` 拦截并提示；一致 → 正常提交。登录模式不渲染确认密码字段，`validate()` 无规则可校验，登录流程不受影响
