### PR TITLE
fix(danmaku): B站数据包解析不再对畸形输入 panic，解码 panic 不再终结录制

### DIFF
--- a/crates/danmaku/src/client.rs
+++ b/crates/danmaku/src/client.rs
@@ -22,9 +22,28 @@ use tracing::{debug, error, info, warn};
 use crate::error::{DanmakuError, Result};
 use crate::output::xml::{XmlWriter, XmlWriterConfig};
 use crate::protocols::{
-    ConnectionInfo, ConnectionTransport, HeartbeatData, Platform, PlatformContext,
+    ConnectionInfo, ConnectionTransport, DecodeResult, HeartbeatData, Platform, PlatformContext,
     RegistrationData, create_platform,
 };
+
+/// 捕获平台解码器的 panic，降级为解码错误：
+/// 录制任务在 tokio::spawn 中运行，panic 会直接杀死任务且没有任何
+/// 重启机制，一条畸形消息就会让弹幕录制静默永久停止。
+fn decode_message_guarded(
+    platform: &dyn Platform,
+    data: &[u8],
+    platform_name: &str,
+) -> Result<DecodeResult> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| platform.decode_message(data)))
+        .unwrap_or_else(|_| {
+            error!(
+                "{}: decoder panicked on a {}-byte message, skipping it",
+                platform_name,
+                data.len()
+            );
+            Err(DanmakuError::Decode("decoder panicked".to_string()))
+        })
+}
 
 /// Configuration for the danmaku recorder.
 #[derive(Debug, Clone)]
@@ -433,7 +452,7 @@ impl DanmakuRecorder {
                             };
 
                             // Decode message
-                            match self.platform.decode_message(&data) {
+                            match decode_message_guarded(self.platform.as_ref(), &data, platform_name) {
                                 Ok(result) => {
                                     // Write decoded events
                                     for event in result.events {
@@ -545,7 +564,7 @@ impl DanmakuRecorder {
 
                 frame = read_tcp_frame(&mut tcp_reader) => {
                     let frame = frame?;
-                    match self.platform.decode_message(&frame) {
+                    match decode_message_guarded(self.platform.as_ref(), &frame, platform_name) {
                         Ok(result) => {
                             for event in result.events {
                                 if let Err(e) = xml_writer.write_event(&event) {

--- a/crates/danmaku/src/protocols/bilibili.rs
+++ b/crates/danmaku/src/protocols/bilibili.rs
@@ -38,6 +38,11 @@ const USER_AGENT_STRING: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Apple
 /// Default WebSocket URL.
 const DEFAULT_WS_URL: &str = "wss://broadcastlv.chat.bilibili.com/sub";
 
+/// Maximum nesting depth for compressed packets.
+/// The real protocol only nests one level (compressed packet contains raw packets);
+/// deeper nesting indicates malformed or hostile input.
+const MAX_DECODE_DEPTH: u8 = 8;
+
 /// Heartbeat packet.
 /// Header: len=31, header_len=16, ver=1, op=2, seq=1
 /// Body: "[object Object] "
@@ -270,6 +275,10 @@ impl Bilibili {
 
     /// Decode a single packet, handling compression.
     fn decode_packet(data: &[u8]) -> Vec<DecodedPacket> {
+        Self::decode_packet_at_depth(data, 0)
+    }
+
+    fn decode_packet_at_depth(data: &[u8], depth: u8) -> Vec<DecodedPacket> {
         let mut packets = Vec::new();
         let mut offset = 0;
 
@@ -280,6 +289,17 @@ impl Bilibili {
             let operation = BigEndian::read_u32(&data[offset + 8..offset + 12]);
             let _sequence = BigEndian::read_u32(&data[offset + 12..offset + 16]);
 
+            // 声明长度必须至少覆盖 16 字节包头，否则该帧不可信：
+            // packet_len < 16 时反向切片会 panic，packet_len == 0 还会死循环
+            if packet_len < 16 {
+                debug!(
+                    "Malformed packet length {}, dropping remaining {} bytes",
+                    packet_len,
+                    data.len() - offset
+                );
+                break;
+            }
+
             if offset + packet_len > data.len() {
                 break;
             }
@@ -287,16 +307,19 @@ impl Bilibili {
             let body = &data[offset + 16..offset + packet_len];
 
             match version {
+                ver::ZLIB | ver::BROTLI if depth >= MAX_DECODE_DEPTH => {
+                    debug!("Packet nesting exceeds depth {}, dropping", MAX_DECODE_DEPTH);
+                }
                 ver::ZLIB => {
                     // Zlib compressed
                     if let Ok(decompressed) = decompress_zlib(body) {
-                        packets.extend(Self::decode_packet(&decompressed));
+                        packets.extend(Self::decode_packet_at_depth(&decompressed, depth + 1));
                     }
                 }
                 ver::BROTLI => {
                     // Brotli compressed
                     if let Ok(decompressed) = decompress_brotli(body) {
-                        packets.extend(Self::decode_packet(&decompressed));
+                        packets.extend(Self::decode_packet_at_depth(&decompressed, depth + 1));
                     }
                 }
                 ver::RAW_JSON | ver::POPULARITY => {
@@ -675,5 +698,77 @@ mod tests {
         let buvid = generate_fake_buvid3();
         assert!(buvid.ends_with("infoc"));
         assert!(buvid.contains("-"));
+    }
+
+    /// 构造指定协议版本的数据包（build_packet 固定 ver=1）。
+    fn build_packet_with_version(body: &[u8], operation: u32, version: u16) -> Vec<u8> {
+        let mut packet = build_packet(body, operation);
+        packet[6..8].copy_from_slice(&version.to_be_bytes());
+        packet
+    }
+
+    fn zlib_compress(data: &[u8]) -> Vec<u8> {
+        use flate2::Compression;
+        use flate2::write::ZlibEncoder;
+        use std::io::Write;
+
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    /// packet_len=0：修复前反向切片 panic（若跳过切片还会因 offset 不前进死循环）。
+    #[test]
+    fn malformed_zero_length_packet_does_not_panic_or_hang() {
+        let mut packet = build_packet(br#"{"cmd":"TEST"}"#, op::NOTIFICATION);
+        packet[0..4].copy_from_slice(&0u32.to_be_bytes());
+
+        assert!(Bilibili::decode_packet(&packet).is_empty());
+    }
+
+    /// packet_len < 16（小于包头长度）：修复前 &data[offset+16..offset+packet_len] 直接 panic。
+    #[test]
+    fn malformed_short_length_packet_does_not_panic() {
+        let mut packet = build_packet(br#"{"cmd":"TEST"}"#, op::NOTIFICATION);
+        packet[0..4].copy_from_slice(&8u32.to_be_bytes());
+
+        assert!(Bilibili::decode_packet(&packet).is_empty());
+    }
+
+    /// 合法包之后跟畸形头：保留已解析的包，丢弃不可信的剩余数据。
+    #[test]
+    fn valid_packet_before_malformed_header_is_preserved() {
+        let body = br#"{"cmd":"TEST"}"#;
+        let mut data = build_packet(body, op::NOTIFICATION);
+        let mut garbage = build_packet(b"x", op::NOTIFICATION);
+        garbage[0..4].copy_from_slice(&3u32.to_be_bytes());
+        data.extend_from_slice(&garbage);
+
+        let decoded = Bilibili::decode_packet(&data);
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].body, body);
+    }
+
+    /// 正常一层压缩嵌套（真实协议形态）仍能解码。
+    #[test]
+    fn single_level_zlib_packet_still_decodes() {
+        let body = br#"{"cmd":"TEST"}"#;
+        let inner = build_packet(body, op::NOTIFICATION);
+        let packet = build_packet_with_version(&zlib_compress(&inner), op::NOTIFICATION, ver::ZLIB);
+
+        let decoded = Bilibili::decode_packet(&packet);
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].body, body);
+    }
+
+    /// 超过深度上限的恶意多层压缩嵌套被丢弃，不发生栈溢出。
+    #[test]
+    fn deeply_nested_compressed_packets_are_dropped() {
+        let mut data = build_packet(br#"{"cmd":"TEST"}"#, op::NOTIFICATION);
+        for _ in 0..(MAX_DECODE_DEPTH as usize + 8) {
+            data = build_packet_with_version(&zlib_compress(&data), op::NOTIFICATION, ver::ZLIB);
+        }
+
+        assert!(Bilibili::decode_packet(&data).is_empty());
     }
 }


### PR DESCRIPTION
## 问题

B 站弹幕协议的 `decode_packet` 只检查 `packet_len` 是否越过缓冲区末尾，没有校验它不小于 16 字节包头本身：

1. **畸形帧直接 panic**：远端（或被劫持的中间节点）发来 `packet_len < 16` 的帧时，`&data[offset + 16..offset + packet_len]` 反向切片立即 panic；`packet_len = 0` 即使跳过切片也会因 `offset` 不前进陷入死循环
2. **崩溃后无法自愈**：panic 发生在 `tokio::spawn` 的录制任务中，`run()` 的 30 秒重连逻辑只处理 `Err` 返回值，任务被 panic 杀死后没有任何重启机制——弹幕录制静默永久停止，XML 文件也不会 finalize
3. 压缩包递归解码没有深度限制，恶意多层 zlib/brotli 嵌套可导致栈溢出（同样是 panic → 任务死亡）

## 修复

- `packet_len < 16` 视为不可信帧：丢弃该帧起的剩余数据、保留此前已解析的包，同时消除 `packet_len = 0` 的死循环隐患
- 压缩包递归增加深度上限 `MAX_DECODE_DEPTH = 8`（真实协议仅一层嵌套），超限直接丢弃
- 客户端在 WebSocket 与 TCP 两条消息路径上以 `catch_unwind` 包裹 `decode_message`：任何平台解码器 panic 都降级为可跳过的解码错误并记录日志，连接与录制继续存活——对全部平台解码器生效，不止 B 站

## 测试

- [x] `cargo test -p danmaku`：43 通过（新增 5 项）
- [x] 新增回归测试：
  - 零长度帧不 panic 不死循环（修复前反向切片 panic）
  - `packet_len = 8` 短长度帧不 panic
  - 合法帧后跟畸形头：保留已解析的包，丢弃不可信数据
  - 单层 zlib 嵌套（真实协议形态）仍正常解码
  - 超过深度上限的多层压缩嵌套被丢弃，无栈溢出
- [x] `cargo check -p biliup-cli` 通过，danmaku 公开 API 无变化
