### PR TITLE
ci: 修复发布与 CI 工作流的权限、死代码及供应链问题

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# 版本控制与 CI
+.git
+.github
+
+# 构建产物（镜像内会重新构建）
+target
+node_modules
+.next
+out
+dist
+tauri-app/node_modules
+tauri-app/src-tauri/target
+
+# 本地运行时数据与凭据，绝不能进入构建上下文
+data
+*.sqlite3
+*.sqlite3-*
+cookies.json
+*.log
+.env.local
+.env.*.local
+
+# 文档站与桌面端与镜像无关
+docs
+tauri-app

--- a/.github/workflows/Termux-publish.yml
+++ b/.github/workflows/Termux-publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
       - name: Build frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ on:
       - main
       - master
     tags:
-      - '*'
+      # 只有严格的版本号 tag 才触发构建与 PyPI 发布，
+      # 避免测试/拼错 tag 误发正式包
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
   workflow_dispatch:
 
@@ -45,7 +47,7 @@ jobs:
             target: ppc64le
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
       - name: Build frontend
@@ -90,7 +92,7 @@ jobs:
             target: armv7
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
       - name: Build frontend
@@ -131,7 +133,7 @@ jobs:
             target: x86
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
       - name: Build frontend
@@ -175,7 +177,7 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
       - name: Build frontend
@@ -207,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
       - name: Build frontend

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,9 +13,10 @@ on:
   # Run tests for any PRs.
   pull_request:
 
+# 顶层只保留读权限：test 任务会在 pull_request 事件下检出并构建
+# PR 代码，不应持有 packages 写权限
 permissions:
   contents: read
-  packages: write
 
 env:
   IMAGE_NAME: ghcr.io/biliup/caution
@@ -47,8 +48,9 @@ jobs:
       - name: Run tests
         run: |
           if [ -f docker-compose.test.yml ]; then
-            docker-compose --file docker-compose.test.yml build
-            docker-compose --file docker-compose.test.yml run sut
+            # runner 已移除 docker-compose v1，统一使用 compose v2 子命令
+            docker compose --file docker-compose.test.yml build
+            docker compose --file docker-compose.test.yml run sut
           else
             docker build \
               --build-arg repo_url=$REPO_URL \
@@ -62,6 +64,9 @@ jobs:
     name: Build for ${{ matrix.platform }}
     runs-on: ${{ matrix.runner }}
     if: github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -78,7 +83,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
-          install: true
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -131,6 +135,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+    permissions:
+      packages: write
 
     steps:
       - name: Download digests

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -3,11 +3,16 @@ name: Zola on GitHub Pages
 on:
   push:
     branches:
-      - master 
+      - master
     paths:
       - docs/**
   pull_request:
-  
+    paths:
+      - docs/**
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,6 +32,9 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
+    permissions:
+      # 推送 gh-pages 分支需要写权限
+      contents: write
     steps:
       - name: Checkout main
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ env:
 #  REPO_NAME: spectralops/rust-ci-release-template
 #  BREW_TAP: jondot/homebrew-tap
 
+permissions:
+  contents: read
+
 jobs:
   dist:
     name: Dist
@@ -69,39 +72,37 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
       - name: Build frontend
         run: |
           npm install
           npm run build
-      - name: Install ${{ matrix.rust }} toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
+
+      # actions-rs/cargo 已归档多年，改用 cross 官方安装方式
+      - name: Install cross
+        if: matrix.cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
 
       - name: Run cargo test
         if: matrix.build != 'aarch64-macos'
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.cross }}
-          command: test
-          args: --release --locked --target ${{ matrix.target }} -p biliup
+        shell: bash
+        run: ${{ matrix.cross && 'cross' || 'cargo' }} test --release --locked --target ${{ matrix.target }} -p biliup
 
       - name: Build release binary
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.cross }}
-          command: build
-          args: --release --locked --target ${{ matrix.target }} --bin biliup
+        shell: bash
+        run: ${{ matrix.cross && 'cross' || 'cargo' }} build --release --locked --target ${{ matrix.target }} --bin biliup
 
       - name: Strip release binary (linux and macos)
         if: matrix.build == 'x86_64-linux' || matrix.build == 'x86_64-macos'
@@ -120,7 +121,8 @@ jobs:
         shell: bash
         run: |
           mkdir dist
-          if [ "${{ matrix.os }}" = "windows-2019" ]; then
+          # 按运行器操作系统判断，matrix.os 的取值（windows-latest）永远不等于 windows-2019
+          if [ "${{ runner.os }}" = "Windows" ]; then
             cp "target/${{ matrix.target }}/release/$BIN_NAME.exe" "dist/"
           else
             cp "target/${{ matrix.target }}/release/$BIN_NAME" "dist/"
@@ -135,9 +137,12 @@ jobs:
     name: Publish
     needs: [dist]
     runs-on: ubuntu-latest
+    permissions:
+      # 向 Release 上传产物需要写权限
+      contents: write
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: false
 
@@ -153,7 +158,7 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             name=${GITHUB_REF:10}
           fi
-          echo ::set-output name=val::$name
+          echo "val=$name" >> "$GITHUB_OUTPUT"
           echo TAG=$name >> $GITHUB_ENV
         id: tagname
 
@@ -168,6 +173,8 @@ jobs:
 
           for dir in bins-* ; do
               platform=${dir#"bins-"}
+              # 每次迭代重置，否则 exe 会从 windows 平台泄漏到后续平台
+              exe=""
               if [[ $platform =~ "windows" ]]; then
                   exe=".exe"
               fi
@@ -196,4 +203,4 @@ jobs:
       - name: Extract version
         id: extract-version
         run: |
-          printf "::set-output name=%s::%s\n" tag-name "${GITHUB_REF#refs/tags/}"
+          echo "tag-name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  rust:
+    name: Rust tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      # biliup-cli 通过 rust-embed 嵌入 out/ 前端产物，需要先构建
+      - name: Build frontend
+        run: |
+          npm install
+          npm run build
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run tests
+        run: cargo test --locked -p biliup -p biliup-cli -p danmaku

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,13 +80,17 @@ RUN set -eux; \
 	apt-mark manual curl wget; \
 	\
 	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
-	url='https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.1-latest-'; \
+	# 固定 FFmpeg 到确定版本并校验 SHA-256：
+	# latest 是滚动 tag，资产每日重建，既不可复现也无法防篡改
+	url='https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-29-13-12/ffmpeg-n8.1.2-50-g1a748fe2cd-'; \
 	case "$arch" in \
 		'amd64') \
 			url="${url}linux64-gpl-8.1.tar.xz"; \
+			sha256='be243f2520d6e7e92c82b015ed72a3f5b57c7970801c0d51f031457122653c76'; \
 		;; \
 		'arm64') \
 			url="${url}linuxarm64-gpl-8.1.tar.xz"; \
+			sha256='0df9277976f71f36b31a4de9f6657a1fbbf32ce2273594c18f19b92fbbbde1ce'; \
 		;; \
 		*) \
 			useApt=true; \
@@ -99,6 +103,7 @@ RUN set -eux; \
 		; \
 	else \
 		wget -O ffmpeg.tar.xz "$url" --progress=dot:giga; \
+		echo "$sha256  ffmpeg.tar.xz" | sha256sum -c -; \
 		tar -xJf ffmpeg.tar.xz -C /usr/local --strip-components=1; \
 		rm -rf \
 			/usr/local/doc \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,13 @@
-version: '3'
 services:
   biliup:
     image: ghcr.io/biliup/caution:latest
     container_name: biliup
     restart: unless-stopped
     ports:
-      - "<HOST_ADDRESS>:<HOST_PORT>:19159"
+      # 可通过环境变量覆盖宿主机端口，例如 BILIUP_PORT=8080 docker compose up -d
+      - "${BILIUP_PORT:-19159}:19159"
     volumes:
-      - /path/to/save_folder:/opt
+      # 录播与数据保存目录，默认使用当前目录下的 data/
+      - ${BILIUP_DATA:-./data}:/opt
     # 容器内必须监听 0.0.0.0，否则上面的端口映射无法转发进容器
     command: server --bind 0.0.0.0 --auth


### PR DESCRIPTION
## 问题

对 6 个工作流、Dockerfile 与 docker-compose.yml 的审查发现多处发布安全与正确性问题：

1. **任意 tag 可发布 PyPI**（ci.yml）：tag 触发是 `'*'`，任何测试/拼错的 tag 都会走到带 `PYPI_API_TOKEN` 的发布任务
2. **PR 工作流持有 packages 写权限**（docker-publish.yml）：顶层 `packages: write` 同样授予 `pull_request` 触发、检出并构建 PR 代码的 test 任务
3. **Windows 归档条件是死代码**（release.yml）：`matrix.os == 'windows-2019'` 与矩阵中的 `windows-latest` 永远不相等，当前 Windows 资产能发出来只是依赖 Git Bash（MSYS）对无扩展名文件的 `.exe` 兜底；同一文件中 `exe` 变量跨循环迭代不重置，平台目录顺序变化时会把 `.exe` 后缀泄漏给非 Windows 平台
4. **弃用/已归档的依赖**：`actions/checkout@v2`（node12 运行时已下线）、`actions-rs/*`（2023 年归档）、`::set-output`、`setup-node@v3`、buildx `install: true`、docker-compose v1 命令
5. **FFmpeg 供应链**（Dockerfile）：从滚动的 `latest` tag 下载且无任何校验，资产每日重建，既不可复现也无法发现篡改
6. **compose 示例无法运行**：`"<HOST_ADDRESS>:<HOST_PORT>:19159"` 占位符导致 `docker compose up` 直接解析失败，而 README 要求直接运行
7. **合并前没有任何测试门禁**：现有 CI 只构建前端和 wheel，不运行任何 Rust 测试
8. **缺少 .dockerignore**：`COPY . /biliup` 会把 `.git`、本地数据库、cookies、日志、`target/`、`node_modules/` 全部送进构建上下文

## 修复

- ci.yml：tag 触发收紧为 `v[0-9]+.[0-9]+.[0-9]+`；setup-node 升 v4
- docker-publish.yml：顶层只读，`packages: write` 移入 build/merge 任务；移除弃用的 `install: true`；compose v1 命令改 v2
- release.yml：`runner.os` 判断 Windows；循环内重置 `exe`；checkout/setup-node 升 v4；actions-rs 替换为 `dtolnay/rust-toolchain` + `taiki-e/install-action`（cross）；`::set-output` 改 `GITHUB_OUTPUT`；顶层 `contents: read`，publish 任务单独授予写权限
- docs-publish.yml / Termux-publish.yml：补显式权限与 paths 过滤；升级弃用版本
- 新增 test.yml：PR 与 master push 运行 `cargo test --locked -p biliup -p biliup-cli -p danmaku`（先构建前端以满足 rust-embed）
- Dockerfile：FFmpeg 固定到 `autobuild-2026-08-29-13-12` 并强制 `sha256sum -c` 校验，失败即终止构建
- docker-compose.yml：占位符改为带默认值的环境变量（`${BILIUP_PORT:-19159}`、`${BILIUP_DATA:-./data}`），开箱即用且可覆盖；移除已废弃的 `version` 字段
- 新增 .dockerignore

## 测试

- [x] `actionlint` 1.7.12 检查全部 7 个工作流（含新增 test.yml）：0 报错
- [x] `docker compose config`：默认值解析为 `19159:19159`，`BILIUP_PORT=8080` 覆盖生效
- [x] FFmpeg 两个固定资产（linux64/arm64）已实际下载并本地计算 SHA-256，与 Dockerfile 中固定值逐字节一致
- [x] test.yml 的测试命令与前端构建步骤已在本地等价执行通过（`npm run build` + 三个 crate 的 `cargo test`）
- [x] 核对 v1.2.3 现有 Release 资产确认 Windows zip 依赖 MSYS 兜底而非该条件分支
