### PR TITLE
docs: 依据代码实现重写 README，迁移弃用域名并修正失效信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://docs.biliup.rs/home.png" alt="description" width="300" height="300"/>
+  <img src="https://raw.githubusercontent.com/biliup/biliup/master/public/logo.png" alt="biliup" width="300" height="300"/>
 </div>
 
 <div align="center">
@@ -128,7 +128,7 @@ biliup download <URL> -o "./video/%Y-%m-%dT%H_%M_%S{title}" --split-time 1h
 
 `--split-size` 与 `--split-time` 可按体积或时长自动分段，`-o` 支持 `{title}` 占位符与 strftime 时间格式。
 
-- [使用文档 »](https://docs.biliup.rs)
+- [使用文档 »](https://biliup.github.io/biliup/docs/guide/introduction/)
 
 ## 🚀 快速开始
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
 
-[![Python](https://img.shields.io/badge/python-3.9%2B-blue)](http://www.python.org/download)
+[![Python](https://img.shields.io/badge/python-3.9%2B-blue)](https://www.python.org/downloads/)
 [![PyPI](https://img.shields.io/pypi/v/biliup)](https://pypi.org/project/biliup)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/biliup)](https://pypi.org/project/biliup)
 [![License](https://img.shields.io/github/license/biliup/biliup)](https://github.com/biliup/biliup/blob/master/LICENSE)
@@ -20,9 +20,37 @@
 * 提供 skill，让你的 Agent 成为 up 主: `npx skills add biliup/biliup`
 * 开箱即用，多种安装方式，提供可视化 WebUi 界面
 * 多主播录制/上传，24X7 无人值守运行，高自定义元信息
+* 录制同时抓取弹幕，输出 XML 弹幕文件
 * 作为自动化流程中的命令行工具封装使用
 
 论坛：[BBS](https://bbs.biliup.rs)
+
+## 📺 支持平台
+
+内置 19 个直播平台解析，未匹配的地址会交给通用适配器（依赖本机的 yt-dlp / Streamlink）尝试处理。
+
+| 平台 | 站点 | 弹幕 |
+| --- | --- | :-: |
+| 哔哩哔哩 | `live.bilibili.com`、`b23.tv` | ✅ |
+| 抖音 | `douyin.com` | ✅ |
+| 斗鱼 | `douyu.com` | ✅ |
+| 虎牙 | `huya.com` | ✅ |
+| 快手 | `kuaishou.com`、`chenzhongtech.com` | |
+| AcFun | `acfun.cn` | |
+| 网易 CC | `cc.163.com` | |
+| 映客 | `inke.cn` | |
+| 猫耳 FM | `missevan.com` | |
+| KilaKila / 红豆 FM | `live.kilakila.cn`、`hongdoufm.com` | |
+| YY | `yy.com` | |
+| TTingLive | `ttinglive.com` | |
+| Twitch | `twitch.tv`（直播与录像） | ✅ |
+| YouTube | `youtube.com`、`youtu.be` | ✅ |
+| TwitCasting | `twitcasting.tv` | ✅ |
+| niconico | `nicovideo.jp` | |
+| AfreecaTV | `afreecatv.com` | |
+| Bigo Live | `bigo.tv` | |
+| Picarto | `picarto.tv` | |
+| 通用适配器 | 其他 `http(s)` 地址 | |
 
 ## 📜 更新日志
 
@@ -40,10 +68,11 @@
 - **[更新日志 »](https://biliup.github.io/biliup/docs/guide/changelog)**
 
 ## 📜 使用文档
-B 站命令行投稿工具，支持**短信登录**、**账号密码登录**、**扫码登录**、**浏览器登录**以及**网页Cookie登录**，并将登录后返回的 cookie 和 token 保存在 `cookie.json` 中，可用于其他项目。
+B 站命令行投稿工具，支持**短信登录**、**账号密码登录**、**扫码登录**、**浏览器登录**以及**网页Cookie登录**，并将登录后返回的 cookie 和 token 保存在 `cookies.json` 中，可用于其他项目。
 
 - 下载 Release: [biliupR](https://github.com/biliup/biliup/releases/latest)
-- 获取命令帮助 `biliup --help` 
+- 获取命令帮助 `biliup --help`
+- 登录信息文件可用 `-u/--user-cookie` 指定，便于多账号切换
 
 **文档地址**：<https://biliup.github.io/biliup-rs>
 ```shell
@@ -91,12 +120,20 @@ Options:
 > 自 [#1660](https://github.com/biliup/biliup/pull/1660) 起，`--bind` 的默认值由 `0.0.0.0` 改为 `127.0.0.1`，即**默认只监听本机**，局域网/公网无法直接访问。
 > 如需从其他设备访问，请加上 `--bind 0.0.0.0 --auth`，详见下方「🔓 远程访问」一节。Docker 镜像已内置该参数，不受影响。
 
+单独下载一场直播/视频，无需启动服务：
+
+```shell
+biliup download <URL> -o "./video/%Y-%m-%dT%H_%M_%S{title}" --split-time 1h
+```
+
+`--split-size` 与 `--split-time` 可按体积或时长自动分段，`-o` 支持 `{title}` 占位符与 strftime 时间格式。
+
 - [使用文档 »](https://docs.biliup.rs)
 
 ## 🚀 快速开始
 
 ### Windows
-- 下载 Release: [bbup-app_0.1.0_x64](https://github.com/biliup/biliup/releases/latest)
+- 下载 Release: [bbup-app](https://github.com/biliup/biliup/releases/latest)
 
 ### Linux 或 macOS
 1. 安装 [uv](https://docs.astral.sh/uv/getting-started/installation/) 
@@ -108,6 +145,9 @@ Options:
   2. [请查看参考](https://biliup.github.io/biliup/docs/guide/introduction/#linuxxia-pei-zhi-kai-ji-zi-qi)
 ### Termux
 - 详见[Wiki](https://github.com/biliup/biliup/wiki/Termux-%E4%B8%AD%E4%BD%BF%E7%94%A8-biliup)
+
+> [!NOTE]
+> 默认下载器 `stream-gears` 由 Rust 实现，无需外部依赖。若配置 `ffmpeg` 下载器或使用后处理，需要本机安装 `ffmpeg`；YouTube、niconico 等平台与通用适配器则依赖 `yt-dlp` 或 `streamlink`。Docker 镜像已内置 `ffmpeg`。
 
 ### 🔓 远程访问（监听 0.0.0.0）
 
@@ -128,6 +168,7 @@ biliup server --bind 0.0.0.0 --auth
 
 > [!WARNING]
 > 将 Web UI 暴露到公网存在风险，建议仅在可信局域网内使用，或置于反向代理之后。
+> 首次访问即可设置管理员密码，请在启动后立即完成初始化，避免被他人抢先占用。
 > 若通过 **HTTPS** 反向代理访问，请加上 `--secure-session-cookie`；直接以 HTTP 远程访问时**不要**加，否则浏览器会丢弃登录态（见 [#1669](https://github.com/biliup/biliup/pull/1669)）。
 
 #### Docker
@@ -138,7 +179,7 @@ biliup server --bind 0.0.0.0 --auth
 docker compose up -d
 ```
 
-打开 `http://your-ip:19159` 设置管理员密码即可。
+打开 `http://your-ip:19159` 设置管理员密码即可。录播与配置默认持久化在容器的 `/opt` 卷中。
 
 > [!IMPORTANT]
 > 若要自定义 `command`，必须带上 `--bind 0.0.0.0`。容器内若监听 `127.0.0.1`，宿主机的端口映射无法转发进容器，Web UI 将完全无法访问。
@@ -206,11 +247,24 @@ graph TB
     style BILI fill:#ffebee
     style STREAMS fill:#ffebee
 ```
+
+### 目录结构
+
+| 路径 | 说明 |
+| --- | --- |
+| `crates/biliup` | 核心库：直播解析、下载器、B 站投稿与凭据管理 |
+| `crates/biliup-cli` | 命令行与 Web 服务：REST API、WebUI 托管、录制调度 |
+| `crates/danmaku` | 弹幕客户端：多平台协议解析与 XML 输出 |
+| `crates/stream-gears` | PyO3 绑定，暴露给 `python -m biliup` |
+| `app`、`public` | Next.js WebUI 源码；`npm run build` 产物输出到 `out/` 并由后端内嵌 |
+| `biliup` | 精简 Python 包：最小入口与可供外部调用的投稿库 |
+| `tauri-app` | 桌面端外壳（实验性） |
+
 </details>
 
 ### frontend
 
-1. 确保 Node.js 版本 ≥ 18
+1. 确保 Node.js 版本 ≥ 18.17（Next.js 14 要求）
 2. 安装依赖：`npm i`
 3. 启动开发服务器：`npm run dev`
 4. 访问：`http://localhost:3000`
@@ -226,6 +280,15 @@ graph TB
 1. `npm run build`
 2. 构建 `cargo build --release --bin biliup`
 3. 开发启动 BiliupR：`cargo run`
+
+> [!NOTE]
+> `biliup-cli` 通过 `rust-embed` 内嵌前端产物目录 `out/`，因此在 `cargo build` / `cargo test` 之前必须先执行 `npm run build`，否则编译会因 `out/` 不存在而失败。
+
+### 测试
+
+```shell
+cargo test -p biliup -p biliup-cli -p danmaku
+```
 
 ## 🤝Credits
 * Thanks `ykdl, youtube-dl, streamlink` provides downloader.

--- a/SKILL.md
+++ b/SKILL.md
@@ -90,20 +90,6 @@ try {
 
 If the target directory is not on `PATH`, tell the user to run `biliup` by its full path or add the target directory to `PATH`.
 
-### Windows winget
-
-Use this path when the user is on Windows and wants to install from the command line:
-
-```bash
-winget install biliup
-```
-
-Then verify:
-
-```bash
-biliup --help
-```
-
 ### Linux or macOS uv
 
 Use this path when the user is on Linux or macOS and has `uv` available:


### PR DESCRIPTION
## 问题

README 中若干信息与当前代码实现不符，或已随版本演进失效：

1. **登录信息文件名错误**：正文写 `cookie.json`，但 CLI 默认值是 `cookies.json`（`crates/biliup-cli/src/cli.rs:31`，且 `server_defaults_to_loopback_and_default_cookie_file` 单测明确断言该值）。按文档操作会找不到凭据文件
2. **已弃用的 `biliup.rs` 文档域名**：顶部 logo 与「使用文档」链接均指向 `docs.biliup.rs`，该域名已弃用且无法访问，导致 README 首屏图片破图
3. **Windows 下载链接硬编码版本**：`bbup-app_0.1.0_x64` 随发版即失效
4. **Python 徽章链接 404**：`http://www.python.org/download` 已失效
5. **Node.js 版本要求偏低**：写 `≥ 18`，但仓库使用 Next.js 14，实际下限为 `18.17`
6. **`SKILL.md` 中的 winget 安装方式失效**：`winget install biliup` 返回 `No package found matching input criteria`；winget 上现有的 `ForgQi.biliup-app`(0.6.7) 与 `ForgQi.biliup-rs`(0.2.4) 均已停止更新，远落后于当前 1.2.4
7. **缺少关键信息**：没有支持平台列表、没有 `download` 子命令用法、未说明 `ffmpeg`/`yt-dlp`/`streamlink` 等外部依赖、未说明 `cargo build` 前必须先 `npm run build`（`biliup-cli` 经 `rust-embed` 内嵌 `out/`，缺失会直接编译失败）

## 修复

保持原有结构、标题层级、emoji 与徽章排版不变，仅按代码逐项校对并补充：

**修正**（均已核实来源）
- `cookie.json` → `cookies.json`
- 文档域名迁移至 `https://biliup.github.io/biliup/docs/guide/introduction/`
- 顶部 logo 改用仓库内 `public/logo.png` 的 raw 链接。README 同时作为 PyPI 长描述使用（`pyproject.toml` 的 `readme = "README.md"`），因此用绝对地址而非相对路径
- Windows 下载链接改为指向 Release 页，不再硬编码版本
- Python 徽章链接改为 `https://www.python.org/downloads/`
- Node.js 要求修正为 `≥ 18.17`
- `SKILL.md` 删除 Windows winget 段落；Windows 用户仍由既有的 GitHub Releases 段落（含 PowerShell 安装脚本）覆盖

**新增**
- `## 📺 支持平台` 表格：依据 `builtin_plugins()` 的 19 个平台适配器 + 通用兜底适配器，站点域名逐个取自各适配器的匹配正则；「弹幕」列依据 `danmaku` 的 `create_platform()` 实际支持的 7 个平台标注
- `download` 子命令示例与 `--split-size` / `--split-time` / `-o` 模板说明
- 外部依赖说明：默认 `stream-gears` 为纯 Rust 实现无需外部程序；`ffmpeg` 下载器与后处理需 `ffmpeg`；YouTube、niconico 与通用适配器需 `yt-dlp` 或 `streamlink`
- 开发章节：目录结构表、`npm run build` 前置说明、测试命令
- Docker `/opt` 持久化说明，以及首次访问尽快初始化管理员的安全提示

## 测试

- [x] CLI 帮助文本与实际输出逐字核对：构建 `target/debug/biliup` 后比对 `--help`、`server --help`、`download --help`，README 中的两处 help 代码块与真实输出完全一致
- [x] 远程访问拒绝启动的报错取自实际运行 `biliup server --bind 0.0.0.0` 的输出，非手写
- [x] `download` 示例实测：`biliup download <URL> -o "./video/%Y-%m-%dT%H_%M_%S{title}" --split-time 1h` 参数解析与平台分发均正常（仅因示例房间号不存在而在网络请求处终止）
- [x] mermaid 架构图经 `@mermaid-js/mermaid-cli` 11.16.0 渲染通过，输出有效 SVG
- [x] README 全部 29 个链接（含图片与自动链接）联网复查，均返回 200；新 logo 地址返回 `image/png`、65525 字节
- [x] `winget install biliup` 与 `winget show biliup` 实测确认无匹配包，并对照 `winget search biliup` 结果确认现存包版本已停更
- [x] 平台表与弹幕列逐项对照 `builtin_plugins()`、各适配器正则与 `create_platform()` 复核
- [x] 文件编码校验：无 BOM、严格 UTF-8 解码通过、无替换字符

### 说明

- Stars 徽章指向的 `github.com/biliup/biliup/stargazers` 对未登录请求返回 404，这是 GitHub 的反爬行为（`rust-lang/rust/stargazers` 同样如此），浏览器访问正常，故保持原样
- 论坛链接 `bbs.biliup.rs` 实测仍返回 200，属独立服务，本 PR 未改动。若该域名同样计划下线，请告知，可一并调整
